### PR TITLE
Issue #16: Solana.Unity.Rpc.SolanaRpcClient.SendTransactionAsync doesn't block until the required completion status

### DIFF
--- a/src/Solana.Unity.Rpc/IRpcClient.cs
+++ b/src/Solana.Unity.Rpc/IRpcClient.cs
@@ -1136,20 +1136,20 @@ namespace Solana.Unity.Rpc
         /// </summary>
         /// <param name="transaction">The signed transaction as base-64 encoded string.</param>
         /// <param name="skipPreflight">If true skip the prflight transaction checks (default false).</param>
-        /// <param name="preFlightCommitment">The block commitment used for preflight.</param>
+        /// <param name="commitment">The block commitment used for preflight and transaction commitment.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<string>> SendTransactionAsync(string transaction, bool skipPreflight = false,
-            Commitment preFlightCommitment = Commitment.Finalized);
+            Commitment commitment = Commitment.Finalized);
 
         /// <summary>
         /// Sends a transaction.
         /// </summary>
         /// <param name="transaction">The signed transaction as base-64 encoded string.</param>
         /// <param name="skipPreflight">If true skip the prflight transaction checks (default false).</param>
-        /// <param name="preFlightCommitment">The block commitment used for preflight.</param>
+        /// <param name="commitment">The block commitment used for preflight and transaction commitment.</param>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
         RequestResult<string> SendTransaction(string transaction, bool skipPreflight = false,
-            Commitment preFlightCommitment = Commitment.Finalized);
+            Commitment commitment = Commitment.Finalized);
 
         /// <summary>
         /// Sends a transaction.

--- a/src/Solana.Unity.Rpc/SolanaRpcClient.cs
+++ b/src/Solana.Unity.Rpc/SolanaRpcClient.cs
@@ -974,16 +974,16 @@ namespace Solana.Unity.Rpc
 
         /// <inheritdoc cref="IRpcClient.SendTransactionAsync(byte[], bool, Commitment)"/>
         public async Task<RequestResult<string>> SendTransactionAsync(byte[] transaction, bool skipPreflight = false,
-            Commitment preflightCommitment = Commitment.Finalized)
+            Commitment commitment = Commitment.Finalized)
         {
-            return await SendTransactionAsync(Convert.ToBase64String(transaction), skipPreflight, preflightCommitment)
+            return await SendTransactionAsync(Convert.ToBase64String(transaction), skipPreflight, commitment)
                 .ConfigureAwait(false);
         }
 
 
         /// <inheritdoc cref="IRpcClient.SendTransactionAsync(string, bool, Commitment)"/>
         public async Task<RequestResult<string>> SendTransactionAsync(string transaction, bool skipPreflight = false,
-            Commitment preflightCommitment = Commitment.Finalized)
+            Commitment commitment = Commitment.Finalized)
         {
             return await SendRequestAsync<string>("sendTransaction",
                 Parameters.Create(
@@ -991,19 +991,20 @@ namespace Solana.Unity.Rpc
                     ConfigObject.Create(
                         KeyValue.Create("skipPreflight", skipPreflight ? skipPreflight : null),
                         KeyValue.Create("preflightCommitment",
-                            preflightCommitment == Commitment.Finalized ? null : preflightCommitment),
-                        KeyValue.Create("encoding", BinaryEncoding.Base64))));
+                            commitment == Commitment.Finalized ? null : commitment),
+                        KeyValue.Create("encoding", BinaryEncoding.Base64),
+                        HandleCommitment(commitment))));
         }
 
         /// <inheritdoc cref="IRpcClient.SendTransaction(string, bool, Commitment)"/>
         public RequestResult<string> SendTransaction(string transaction, bool skipPreFlight = false,
-            Commitment preFlightCommitment = Commitment.Finalized)
-            => SendTransactionAsync(transaction, skipPreFlight, preFlightCommitment).Result;
+            Commitment commitment = Commitment.Finalized)
+            => SendTransactionAsync(transaction, skipPreFlight, commitment).Result;
 
         /// <inheritdoc cref="IRpcClient.SendTransactionAsync(byte[], bool, Commitment)"/>
         public RequestResult<string> SendTransaction(byte[] transaction, bool skipPreFlight = false,
-            Commitment preFlightCommitment = Commitment.Finalized)
-            => SendTransactionAsync(transaction, skipPreFlight, preFlightCommitment).Result;
+            Commitment commitment = Commitment.Finalized)
+            => SendTransactionAsync(transaction, skipPreFlight, commitment).Result;
 
         /// <inheritdoc cref="IRpcClient.SimulateTransactionAsync(string, bool, Commitment, bool, IList{string})"/>
         public async Task<RequestResult<ResponseValue<SimulationLogs>>> SimulateTransactionAsync(string transaction,


### PR DESCRIPTION


| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug| Yes | [Link](https://github.com/garbles-labs/Solana.Unity-Core/issues/16) |

## Problem

https://github.com/garbles-labs/Solana.Unity-Core/issues/16

## Solution

I added a method to block the task thread until the transaction's status reached the desired commitment level (but only if the transaction had successfully sent), then called it from the SendTransactionAsync method in SolanaRpcClient.cs. 

I also added a stub method for blocking using the websocket feed, which would be the preferred way. However, I was not able to get that to work in time, so in the meantime (until that can be made to work), I am using an alternate method which polls with http requests instead, to accomplish the same goal. 

