### PR TITLE
:ambulance: Avoid failing with empty private key

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,8 @@ jobs:
         uses: cake-build/cake-action@v1.4.1
         with:
           cake-version: 1.1.0
-          verbosity: Verbose
+          verbosity: Diagnostic
+          target: Report
       - name: Publish coverage report to coveralls.io
         uses: coverallsapp/github-action@v1.1.2
         with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,26 +1,35 @@
-name: .NET
-
+name: .NET Tests
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
-
+    branches:
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Get the sources
-        uses: actions/checkout@v1
-      - name: Run the build script
-        uses: cake-build/cake-action@v1.4.1
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
         with:
-          cake-version: 1.1.0
-          verbosity: Diagnostic
-          cake-bootstrap: true
-          target: Report
+          dotnet-version: 6.0.x
+      - name: Check out Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run cake
+        shell : bash
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dotnet new tool-manifest
+          dotnet tool install Cake.Tool --version 1.1.0
+          dotnet tool restore
+          dotnet cake --target=Report --verbosity=verbose
       - name: Publish coverage report to coveralls.io
         uses: coverallsapp/github-action@v1.1.2
         with:
-          github-token: ${{ secrets.github_token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: code_coverage/results.info 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,10 +13,11 @@ jobs:
       - name: Get the sources
         uses: actions/checkout@v1
       - name: Run the build script
-        uses: cake-build/cake-action@v1.4.1
+        uses: cake-build/cake-action@v1
         with:
           script-path: build.cake
           target: Report
+          cake-version: 1.1.0
           cake-bootstrap: true
           verbosity: Diagnostic
       - name: Publish coverage report to coveralls.io

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           cake-version: 1.1.0
           verbosity: Diagnostic
+          cake-bootstrap: true
           target: Report
       - name: Publish coverage report to coveralls.io
         uses: coverallsapp/github-action@v1.1.2

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,7 +21,7 @@ jobs:
           cake-bootstrap: true
           verbosity: Diagnostic
       - name: Publish coverage report to coveralls.io
-        uses: coverallsapp/github-action@v1.1.3
+        uses: coverallsapp/github-action@v1.1.2
         with:
           github-token: ${{ secrets.github_token }}
           path-to-lcov: code_coverage/results.info 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,7 +24,6 @@ jobs:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          dotnet new tool-manifest
           dotnet tool install Cake.Tool --version 1.1.0
           dotnet tool restore
           dotnet cake --target=Report --verbosity=verbose

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Get the sources
         uses: actions/checkout@v1
       - name: Run the build script
-        uses: cake-build/cake-action@v1
+        uses: cake-build/cake-action@v1.4.1
         with:
           script-path: build.cake
           target: Report
@@ -21,7 +21,7 @@ jobs:
           cake-bootstrap: true
           verbosity: Diagnostic
       - name: Publish coverage report to coveralls.io
-        uses: coverallsapp/github-action@v1.1.2
+        uses: coverallsapp/github-action@v1.1.3
         with:
           github-token: ${{ secrets.github_token }}
           path-to-lcov: code_coverage/results.info 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,11 +15,8 @@ jobs:
       - name: Run the build script
         uses: cake-build/cake-action@v1.4.1
         with:
-          script-path: build.cake
-          target: Report
           cake-version: 1.1.0
-          cake-bootstrap: true
-          verbosity: Diagnostic
+          verbosity: Verbose
       - name: Publish coverage report to coveralls.io
         uses: coverallsapp/github-action@v1.1.2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
 name: Build, Pack & Publish
 
 on:
-  push:
-    branches:
-      - master # Default release branch
+  release:
+    types: [published]
+  # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 jobs:
   publish:
@@ -16,11 +16,14 @@ jobs:
         run: |
             git log --pretty=format:'%s' ${GITHUB_REF} | perl -pe 's| \(.*tag: v(\d+.\d+.\d+(-preview\d{3})?)(, .*?)*\)|\n## \1\n|g' > RELEASE-NOTES.txt
       - name: Run the build script
-        uses: cake-build/cake-action@v1
-        with:
-          script-path: build.cake
-          target: Pack
-          cake-bootstrap: true
+        shell : bash
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dotnet tool install Cake.Tool --version 1.1.0
+          dotnet tool restore
+          dotnet cake --target=Pack --verbosity=verbose
       - name: Publish Solana.Unity.Extensions on version change
         uses: rohith/publish-nuget@v2
         with:

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@
   </p>
 
   <p>
-    <a href="https://github.com/garbles-dev/Solana.Unity/actions/workflows/dotnet.yml">
-        <img src="https://github.com/garbles-dev/Solana.Unity/actions/workflows/dotnet.yml/badge.svg"
+    <a href="https://github.com/garbles-labs/Solana.Unity-Core/actions/workflows/dotnet.yml">
+        <img src="https://github.com/garbles-labs/Solana.Unity-Core/actions/workflows/dotnet.yml/badge.svg"
             alt="Build" ></a>
-    <a href="https://github.com/garbles-dev/Solana.Unity/actions/workflows/publish.yml">
+    <a href="https://github.com/garbles-labs/Solana.Unity-Core/actions/workflows/publish.yml">
        <img src="https://github.com/garbles-dev/Solana.Unity/actions/workflows/publish.yml/badge.svg" 
             alt="Release"></a>
-    <a href="https://coveralls.io/garbles-dev/Solana.Unity/Solnet?branch=master">
-        <img src="https://coveralls.io/repos/github/garbles-dev/Solana.Unity/badge.svg?branch=master" 
+    <a href="https://coveralls.io/github/garbles-labs/Solana.Unity-Core?branch=master">
+        <img src="https://coveralls.io/repos/github/garbles-labs/Solana.Unity-Core/badge.svg?branch=master" 
             alt="Coverage Status" ></a>
     <a href="">
-        <img src="https://img.shields.io/github/license/garbles-dev/Solana.Unity?style=flat-square"
+        <img src="https://img.shields.io/github/license/garbles-labs/Solana.Unity-Core?style=flat-square"
             alt="Code License"></a>
     <a href="https://twitter.com/intent/follow?screen_name=garblesfun">
         <img src="https://img.shields.io/twitter/follow/garblesfun?style=flat-square&logo=twitter"

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,5 @@
-#module nuget:?package=Cake.DotNetTool.Module&version=0.4.0
 #addin nuget:?package=Cake.Coverlet&version=2.5.4
-#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=4.8.7
+#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=5.1.13
 
 var testProjectsRelativePaths = new string[]
 {

--- a/src/Solana.Unity.Wallet/PrivateKey.cs
+++ b/src/Solana.Unity.Wallet/PrivateKey.cs
@@ -98,10 +98,13 @@ namespace Solana.Unity.Wallet
         /// <returns>The signature of the data.</returns>
         public byte[] Sign(byte[] message)
         {
-            ArraySegment<byte> signature = new ArraySegment<byte>(new byte[64]);
-            Ed25519.Sign(signature, 
-                new ArraySegment<byte>(message), 
-                new ArraySegment<byte>(KeyBytes));
+            ArraySegment<byte> signature = new(new byte[64]);
+            if (!string.IsNullOrEmpty(Key))
+            {
+                Ed25519.Sign(signature, 
+                    new ArraySegment<byte>(message), 
+                    new ArraySegment<byte>(KeyBytes));
+            }
             return signature.Array;
         }
 

--- a/test/Solana.Unity.Rpc.Test/TransactionBuilderTest.cs
+++ b/test/Solana.Unity.Rpc.Test/TransactionBuilderTest.cs
@@ -131,6 +131,21 @@ namespace Solana.Unity.Rpc.Test
         }
 
         [TestMethod]
+        public void TestTransactionBuilderEmptyPrivateKey()
+        {
+            Account account = new Account(string.Empty, new PublicKey("2S1kjspXLPs6jpNVXQfNMqZzzSrKLbGdr9Fxap5h1DLN"));
+            byte[] tx = new TransactionBuilder()
+                .SetRecentBlockHash(Blockhash)
+                .SetFeePayer(account)
+                .AddInstruction(SystemProgram.Transfer(account, account.PublicKey, 10000000))
+                .AddInstruction(MemoProgram.NewMemo(account, "Hello from Sol.Net :)"))
+                .Build(account);
+            Transaction transaction = Transaction.Deserialize(tx);
+            Assert.IsTrue(transaction.Signatures.Count == 1);
+            CollectionAssert.AreEqual(transaction.Signatures[0].Signature, new byte[64]);
+        }
+
+        [TestMethod]
         public void CreateInitializeAndMintToTest()
         {
             var wallet = new Wallet.Wallet(MnemonicWords);


### PR DESCRIPTION
Avoid failing with empty private key, allows the SDK to build transaction before having all the available signatures


| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Hotfix | No |  |

## Problem

The SDK Unity package needs to build transactions with account that may have an empty private key (e.g.: Phantom, before sending the transaction for signature)

## Solution

Build the transaction and add an empty signature when the private key is empty