### PR TITLE
:zap: Add ability to run without Unity

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -11,8 +11,7 @@ var testProjectsRelativePaths = new string[]
 };
 
 var target = Argument("target", "Pack");
-var configuration = Argument("configuration", "Debug");
-var configurationRelease = Argument("configuration", "Release");
+var configuration = Argument("configuration", "Release");
 var solutionFolder = "./";
 var artifactsDir = MakeAbsolute(Directory("artifacts"));
 
@@ -44,17 +43,6 @@ Task("Build")
         {
             NoRestore = true,
             Configuration = configuration
-        });
-    });
-
-Task("BuildRelease")
-    .IsDependentOn("Clean")
-    .IsDependentOn("Restore")
-    .Does(() => {
-        DotNetCoreBuild(solutionFolder, new DotNetCoreBuildSettings
-        {
-            NoRestore = true,
-            Configuration = configurationRelease
         });
     });
     
@@ -104,12 +92,12 @@ Task("Report")
 
 Task("Publish")
     .IsDependentOn("Report")
-    .IsDependentOn("BuildRelease")
+    .IsDependentOn("Build")
     .Does(() => {
         DotNetCorePublish(solutionFolder, new DotNetCorePublishSettings
         {
             NoRestore = true,
-            Configuration = configurationRelease,
+            Configuration = configuration,
             NoBuild = true,
             OutputDirectory = artifactsDir
         });
@@ -121,7 +109,7 @@ Task("Pack")
     {
         var settings = new DotNetCorePackSettings
         {
-            Configuration = configurationRelease,
+            Configuration = configuration,
             NoBuild = true,
             NoRestore = true,
             OutputDirectory = packagesDir,

--- a/src/Solana.Unity.Rpc/Core/Http/JsonRpcClient.cs
+++ b/src/Solana.Unity.Rpc/Core/Http/JsonRpcClient.cs
@@ -6,12 +6,10 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using Solana.Unity.Rpc.Converters;
-using System.ComponentModel;
 using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using UnityEngine;
 using UnityEngine.Networking;
 
 namespace Solana.Unity.Rpc.Core.Http
@@ -318,27 +316,7 @@ namespace Solana.Unity.Rpc.Core.Http
             return result;
         }
         
-        /// <summary>
-        /// Return True if running on Unity, False otherwise
-        /// </summary>
-        /// <returns>Return True if running on Unity, False otherwise</returns>
-        private bool IsUnityPlayer()
-        {
-            #if NETSTANDARD2_0 && !DEBUG
-            try
-            {
-                if (Application.platform != null)
-                {
-                    return true;
-                }
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-            #endif
-            return false;
-        }
+        
         
         /// <summary>
         /// Send an async request using HttpClient or UnityWebRequest if running on Unity
@@ -348,7 +326,7 @@ namespace Solana.Unity.Rpc.Core.Http
         /// <returns></returns>
         private async Task<HttpResponseMessage> SendAsyncRequest(HttpClient httpClient, HttpRequestMessage httpReq)
         {
-            if (IsUnityPlayer())
+            if (RuntimePlatform.IsUnityPlayer())
             {
                 return await SendUnityWebRequest(httpClient.BaseAddress, httpReq);
             }

--- a/src/Solana.Unity.Rpc/Solana.Unity.Rpc.csproj
+++ b/src/Solana.Unity.Rpc/Solana.Unity.Rpc.csproj
@@ -12,7 +12,7 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
     </AssemblyAttribute>
-    <PackageReference Include="Newtonsoft.Json" Version="13.*"/>
+    <PackageReference Include="Newtonsoft.Json" Version="13.*" />
     <PackageReference Include="System.Collections.Immutable" Version="6.*" />
     <PackageReference Include="IsExternalInit" Version="1.0.*" PrivateAssets="all" />
     <PackageReference Include="Unity3D.SDK" Version="2021.*" PrivateAssets="all" />

--- a/src/Solana.Unity.Rpc/Utilities/RuntimePlatform.cs
+++ b/src/Solana.Unity.Rpc/Utilities/RuntimePlatform.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Solana.Unity.Rpc.Utilities;
+
+/// <summary>
+/// A class that contains the information about the runtime environment.
+/// </summary>
+public static class RuntimePlatform
+{
+    /// <summary>
+    /// Return True if running on Unity, False otherwise
+    /// </summary>
+    /// <returns>Return True if running on Unity, False otherwise</returns>
+    public static bool IsUnityPlayer()
+    {
+        try
+        {
+            if (Type.GetType("UnityEngine.GameObject, UnityEngine") != null)
+            {
+                return true;
+            }
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Add ability to run without Unity

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No |  |

## Problems

- Unable to run the library without unity
- Because of this it was difficult to test external packages using it as a dependency (without Unit Test Runner)


## Solution

Runtime check if is running or not in a Unity app