### PR TITLE
:sparkles: Add transaction confirmation methods

### DIFF
--- a/src/Solana.Unity.Rpc/IRpcClient.cs
+++ b/src/Solana.Unity.Rpc/IRpcClient.cs
@@ -1135,7 +1135,7 @@ namespace Solana.Unity.Rpc
         /// Sends a transaction.
         /// </summary>
         /// <param name="transaction">The signed transaction as base-64 encoded string.</param>
-        /// <param name="skipPreflight">If true skip the prflight transaction checks (default false).</param>
+        /// <param name="skipPreflight">If true skip the preflight transaction checks (default false).</param>
         /// <param name="preFlightCommitment">The block commitment used for preflight.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<string>> SendTransactionAsync(string transaction, bool skipPreflight = false,
@@ -1145,7 +1145,7 @@ namespace Solana.Unity.Rpc
         /// Sends a transaction.
         /// </summary>
         /// <param name="transaction">The signed transaction as base-64 encoded string.</param>
-        /// <param name="skipPreflight">If true skip the prflight transaction checks (default false).</param>
+        /// <param name="skipPreflight">If true skip the preflight transaction checks (default false).</param>
         /// <param name="preFlightCommitment">The block commitment used for preflight.</param>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
         RequestResult<string> SendTransaction(string transaction, bool skipPreflight = false,
@@ -1155,7 +1155,7 @@ namespace Solana.Unity.Rpc
         /// Sends a transaction.
         /// </summary>
         /// <param name="transaction">The signed transaction as byte array.</param>
-        /// <param name="skipPreflight">If true skip the prflight transaction checks (default false).</param>
+        /// <param name="skipPreflight">If true skip the preflight transaction checks (default false).</param>
         /// <param name="commitment">The block commitment used to retrieve block hashes and verify success.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<string>> SendTransactionAsync(byte[] transaction, bool skipPreflight = false,
@@ -1165,11 +1165,55 @@ namespace Solana.Unity.Rpc
         /// Sends a transaction.
         /// </summary>
         /// <param name="transaction">The signed transaction as byte array.</param>
-        /// <param name="skipPreflight">If true skip the prflight transaction checks (default false).</param>
+        /// <param name="skipPreflight">If true skip the preflight transaction checks (default false).</param>
         /// <param name="commitment">The block commitment used to retrieve block hashes and verify success.</param>
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
         RequestResult<string> SendTransaction(byte[] transaction, bool skipPreflight = false,
             Commitment commitment = Commitment.Finalized);
+        
+        /// <summary>
+        /// Sends and confirm transaction.
+        /// </summary>
+        /// <param name="transaction">The signed transaction as byte array.</param>
+        /// <param name="skipPreflight">If true skip the preflight transaction checks (default false).</param>
+        /// <param name="preFlightCommitment">The block commitment used for preflight.</param>
+        /// <param name="commitment">The block commitment used for confirmation.</param>
+        /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
+        Task<RequestResult<string>> SendAndConfirmTransactionAsync(byte[] transaction, bool skipPreflight = false,
+            Commitment preFlightCommitment = Commitment.Finalized, Commitment commitment = Commitment.Finalized);
+        
+        /// <summary>
+        /// Sends and confirm a transaction.
+        /// </summary>
+        /// <param name="transaction">The signed transaction as base-64 encoded string.</param>
+        /// <param name="skipPreflight">If true skip the preflight transaction checks (default false).</param>
+        /// <param name="preFlightCommitment">The block commitment used for preflight.</param>
+        /// <param name="commitment">The block commitment used for confirmation.</param>
+        /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
+        Task<RequestResult<string>> SendAndConfirmTransactionAsync(string transaction, bool skipPreflight = false,
+            Commitment preFlightCommitment = Commitment.Finalized, Commitment commitment = Commitment.Finalized);
+        
+        /// <summary>
+        /// Sends and confirm a transaction.
+        /// </summary>
+        /// <param name="transaction">The signed transaction as base-64 encoded string.</param>
+        /// <param name="skipPreflight">If true skip the preflight transaction checks (default false).</param>
+        /// <param name="preFlightCommitment">The block commitment used for preflight.</param>
+        /// <param name="commitment">The block commitment used for confirmation.</param>
+        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
+        RequestResult<string> SendAndConfirmTransaction(string transaction, bool skipPreflight = false,
+            Commitment preFlightCommitment = Commitment.Finalized, Commitment commitment = Commitment.Finalized);
+
+        /// <summary>
+        /// Sends and confirm a transaction.
+        /// </summary>
+        /// <param name="transaction">The signed transaction as byte array.</param>
+        /// <param name="skipPreflight">If true skip the preflight transaction checks (default false).</param>
+        /// <param name="preFlightCommitment">The block commitment used for preflight.</param>
+        /// <param name="commitment">The block commitment used for confirmation.</param>
+        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
+        RequestResult<string> SendAndConfirmTransaction(byte[] transaction, bool skipPreflight = false,
+            Commitment preFlightCommitment = Commitment.Finalized, Commitment commitment = Commitment.Finalized);
 
         /// <summary>
         /// Simulate sending a transaction.
@@ -1226,6 +1270,14 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
         RequestResult<ResponseValue<SimulationLogs>> SimulateTransaction(byte[] transaction, bool sigVerify = false,
             Commitment commitment = Commitment.Finalized, bool replaceRecentBlockhash = false, IList<string> accountsToReturn = null);
+
+        /// <summary>
+        /// Confirms a transaction - using polling and constant timeout based on commitment parameter.
+        /// </summary>
+        /// <param name="hash">The hash of the transaction.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <returns>Returns null if the transaction wasn't confirmed, otherwise returns the confirmation slot and possible transaction error.</returns>
+        Task<bool> ConfirmTransaction(string hash, Commitment commitment = Commitment.Finalized);
 
         /// <summary>
         /// Low-level method to send a batch of JSON RPC requests

--- a/src/Solana.Unity.Rpc/TransactionUtils.cs
+++ b/src/Solana.Unity.Rpc/TransactionUtils.cs
@@ -1,0 +1,133 @@
+using Solana.Unity.Rpc.Core.Http;
+using Solana.Unity.Rpc.Messages;
+using Solana.Unity.Rpc.Models;
+using Solana.Unity.Rpc.Types;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Solana.Unity.Rpc
+{
+    /// <summary>
+    /// Utilities to check transaction confirmation status.
+    /// </summary>
+    public static class TransactionConfirmationUtils
+    {
+        /// <summary>
+        /// Confirms a transaction - same method as web3.js.
+        /// </summary>
+        /// <param name="rpc">The rpc client instance.</param>
+        /// <param name="streamingRpcClient">The streaming rpc client instance.</param>
+        /// <param name="hash">The hash of the transaction.</param>
+        /// <param name="validBlockHeight">The last valid block height of the blockhash used in the transaction.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <returns>Returns null if the transaction wasn't confirmed, otherwise returns the confirmation slot and possible transaction error.</returns>
+        public static async Task<ResponseValue<ErrorResult>> ConfirmTransaction(IRpcClient rpc, IStreamingRpcClient streamingRpcClient, 
+            string hash, ulong validBlockHeight, Commitment commitment = Commitment.Finalized)
+        {
+            TaskCompletionSource<object> t = new();
+            ResponseValue<ErrorResult> result = null;
+
+            var s = await streamingRpcClient.SubscribeSignatureAsync(hash, (s, e) =>
+            {
+                result = e;
+                t.SetResult(null);
+            },
+            commitment);
+
+            var checkTask = Task.Run(async () =>
+            {
+                var currHeight = await rpc.GetBlockHeightAsync(commitment);
+                while (currHeight.Result < validBlockHeight)
+                {
+                    await Task.Delay(1000);
+                    currHeight = await rpc.GetBlockHeightAsync(commitment);
+                }
+            });
+
+
+            Task.WaitAny(t.Task, checkTask);
+
+            if (!t.Task.IsCompleted)
+            {
+                await s.UnsubscribeAsync();
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Confirms a transaction - old web3.js using constant timeout based on commitment parameter.
+        /// </summary>
+        /// <param name="rpc">The rpc client instance.</param>
+        /// <param name="streamingRpcClient">The streaming rpc client instance.</param>
+        /// <param name="hash">The hash of the transaction.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <returns>Returns null if the transaction wasn't confirmed, otherwise returns the confirmation slot and possible transaction error.</returns>
+        public static async Task<ResponseValue<ErrorResult>> ConfirmTransaction(IRpcClient rpc, IStreamingRpcClient streamingRpcClient,
+            string hash, Commitment commitment = Commitment.Finalized)
+        {
+            TaskCompletionSource<object> t = new();
+            ResponseValue<ErrorResult> result = null;
+
+            var s = await streamingRpcClient.SubscribeSignatureAsync(hash, (s, e) =>
+            {
+                result = e;
+                t.SetResult(null);
+            },
+            commitment);
+
+            var timeout = commitment == Commitment.Finalized ? TimeSpan.FromSeconds(60) : TimeSpan.FromSeconds(30);
+            var delay = Task.Delay(timeout);
+
+            Task.WaitAny(t.Task, delay);
+
+            if (!t.Task.IsCompleted)
+            {
+                await s.UnsubscribeAsync();
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Confirms a transaction - using polling and constant timeout based on commitment parameter.
+        /// </summary>
+        /// <param name="rpc">The rpc client instance.</param>
+        /// <param name="hash">The hash of the transaction.</param>
+        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <returns>Returns false if the transaction wasn't confirmed, otherwise returns true.</returns>
+        public static async Task<bool> ConfirmTransaction(
+            IRpcClient rpc, string hash, Commitment commitment = Commitment.Finalized)
+        {
+            //timeout in milliseconds, if commitment level not reached 
+            var timeout = commitment == Commitment.Finalized ? TimeSpan.FromSeconds(60) : TimeSpan.FromSeconds(30);
+            CancellationTokenSource cancelSource = new();
+            CancellationToken cancelToken = cancelSource.Token;
+            cancelSource.CancelAfter(timeout);
+
+            //Commitment.Processed is meaningless here 
+            if (commitment == Commitment.Processed)
+                commitment = Commitment.Confirmed;
+
+            //response must be valid, or else return false 
+            //wait until timeout 
+            while (!cancelToken.IsCancellationRequested)
+            {
+                //try to get completed transaction 
+                RequestResult<TransactionMetaSlotInfo> tx = await rpc.GetTransactionAsync(hash, commitment);
+                if (tx.WasSuccessful)
+                {
+                    await Task.Delay(100);
+                    return true;
+                }
+
+                //delay a bit before retrying 
+                await Task.Delay(300);
+            }
+
+            return false;
+        }
+
+    }
+}


### PR DESCRIPTION
Add transaction confirmation methods

| Status  | Type  | ⚠️ Core Change | Issues | PRs |
| :---: | :---: | :---: | :--: | :--: |
| Ready | Feature | No | #14 #16 | #15 #17 |

## Problem

Missing methods to confirm/wait for transaction completion


## Solution

Add to RpcClient:
- SendAndConfirmTransactionAsync
- SendAndConfirmTransaction

Add utils to confirm transaction with http pooling or websockets
- TransactionConfirmationUtils.ConfirmTransaction

## Discussion 

Adding these methods reduces coverage a bit, tests would need websockets and connection to a node. It can be fixed by adding integration test on a local validator node. 
Leaving this for future work.

## Issues
Closes #14
Closes #15 
Closes #16
Closes #17
