### PR TITLE
:bug: Improvement & Bug Fixes

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,12 @@
       "commands": [
         "dotnet-format"
       ]
+    },
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.1.15",
+      "commands": [
+        "reportgenerator"
+      ]
     }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -615,3 +615,4 @@ riderModule.iml
 /_ReSharper.Caches/
 _site/
 api/
+test-ledger/

--- a/src/Solana.Unity.Dex/IDex.cs
+++ b/src/Solana.Unity.Dex/IDex.cs
@@ -389,26 +389,24 @@ namespace Solana.Unity.Dex
             PublicKey tokenMintA,
             PublicKey tokenMintB,
             PublicKey configAccountAddress = null,
-            ushort tickSpacing = TickSpacing.Standard,
+            ushort tickSpacing = TickSpacing.HundredTwentyEight,
             Commitment? commitment = Commitment.Finalized
         );
-        
+
         /// <summary>
         /// Determines whether or not a whirlpool with the given (or similar) characteristics can be found.
-        /// </summary> 
-        /// <param name="tokenMintA">Mint address of any token associated with the pool, preferably token A.</param> 
-        /// <param name="tokenMintB">Mint address of any token associated with the pool, preferably token B.</param> 
-        /// <param name="tickSpacing">Preferred tickSpacing associated with the pool; if not found, others will be queried.</param> 
+        /// </summary>
+        /// <param name="tokenMintA">Mint address of any token associated with the pool, preferably token A.</param>
+        /// <param name="tokenMintB">Mint address of any token associated with the pool, preferably token B.</param>
+        /// <param name="tickSpacing">Preferred tickSpacing associated with the pool; if not found, others will be queried.</param>
         /// <param name="configAccountAddress">Public key of the whirlpool config address account.</param>
-        /// <param name="commitment">Transaction commitment to use for chain queries.</param> 
-        /// <returns>A boolean value, true if the whirlpool was found.</returns>
-        public abstract Task<PublicKey> FindWhirlpoolAddress(
-            PublicKey tokenMintA,
+        /// <param name="commitment">Transaction commitment to use for chain queries.</param>
+        /// <returns>The pool if found</returns>
+        public Task<Pool> FindWhirlpoolAddress(PublicKey tokenMintA,
             PublicKey tokenMintB,
-            ushort tickSpacing = TickSpacing.Standard,
+            ushort tickSpacing = TickSpacing.HundredTwentyEight,
             PublicKey configAccountAddress = null,
-            Commitment? commitment = Commitment.Finalized
-        );
+            Commitment? commitment = Commitment.Finalized);
         
         /// <summary> 
         /// Creates a quote for a swap for a specified pair of input/output token mint. 

--- a/src/Solana.Unity.Dex/IDex.cs
+++ b/src/Solana.Unity.Dex/IDex.cs
@@ -7,7 +7,6 @@ using Solana.Unity.Rpc.Models;
 using Solana.Unity.Rpc.Types;
 using Solana.Unity.Dex.Ticks;
 using Solana.Unity.Dex.Quotes;
-using Solana.Unity.Dex.Swap;
 using System.Collections.Generic;
 
 namespace Solana.Unity.Dex
@@ -33,10 +32,10 @@ namespace Solana.Unity.Dex
         /// </remarks>
         /// <param name="whirlpoolAddress"></param> 
         /// <param name="amount"></param>
-        /// <param name="inputTokenMintAddress"></param> 
+        /// <param name="inputTokenMintAddress"></param>
+        /// <param name="amountSpecifiedIsInput"></param>
         /// <param name="slippage"></param>
-        /// <param name="amountSpecifiedTokenType"></param>
-        /// <param name="tokenAuthority"></param> 
+        /// <param name="unwrapSol"></param>
         /// <param name="commitment">Transaction commitment on which to base the transaction, and to use for 
         /// any chain queries.</param> 
         /// <returns>The generated Transaction instance</returns>
@@ -44,12 +43,12 @@ namespace Solana.Unity.Dex
             PublicKey whirlpoolAddress,
             BigInteger amount,
             PublicKey inputTokenMintAddress,
+            bool amountSpecifiedIsInput = true,
             double slippage = 0.01,
-            TokenType amountSpecifiedTokenType = TokenType.TokenA,
-            PublicKey tokenAuthority = null,
-            Commitment commitment = Commitment.Finalized
+            bool unwrapSol = true,
+            Commitment? commitment = Commitment.Finalized
         );
-        
+
         /// <summary> 
         /// Constructs a transaction to perform a swap involving the two tokens managed by the specified 
         /// whirlpool. 
@@ -59,14 +58,16 @@ namespace Solana.Unity.Dex
         /// - tokenAuthority
         /// </remarks>
         /// <param name="whirlpoolAddress"></param> 
-        /// <param name="swapQuote"></param> 
+        /// <param name="swapQuote"></param>
+        /// <param name="unwrapSol"></param>
         /// <param name="commitment">Transaction commitment on which to base the transaction, and to use for 
         /// any chain queries.</param> 
         /// <returns>The generated Transaction instance</returns>
         Task<Transaction> SwapWithQuote(
             PublicKey whirlpoolAddress,
             SwapQuote swapQuote,
-            Commitment commitment = Commitment.Finalized
+            bool unwrapSol = true,
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary> 
@@ -88,13 +89,13 @@ namespace Solana.Unity.Dex
         /// any chain queries.</param> 
         /// <returns>The generated Transaction instance</returns>
         Task<Transaction> OpenPosition(
-            PublicKey positionMintAccount,
             PublicKey whirlpoolAddress,
+            PublicKey positionMintAccount,
             int tickLowerIndex,
             int tickUpperIndex,
             bool withMetadata = false,
             PublicKey funderAddress = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary> 
@@ -115,12 +116,12 @@ namespace Solana.Unity.Dex
         /// any chain queries.</param> 
         /// <returns>The generated Transaction instance</returns>
         Task<Transaction> OpenPositionWithMetadata(
-            PublicKey positionMintAccount,
             PublicKey whirlpoolAddress,
+            PublicKey positionMintAccount,
             int tickLowerIndex,
             int tickUpperIndex,
             PublicKey funderAddress,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary> 
@@ -144,23 +145,64 @@ namespace Solana.Unity.Dex
         /// <param name="whirlpoolAddress"></param> 
         /// <param name="tickLowerIndex"></param> 
         /// <param name="tickUpperIndex"></param> 
-        /// <param name="tokenMaxA"></param> 
-        /// <param name="tokenMaxB"></param> 
+        /// <param name="tokenAmountA"></param> 
+        /// <param name="tokenAmountB"></param>
+        /// <param name="slippageTolerance"></param>
         /// <param name="withMetadata"></param> 
         /// <param name="funderAccount"></param> 
         /// <param name="commitment">Transaction commitment on which to base the transaction, and to use for 
         /// any chain queries.</param> 
         /// <returns>The generated Transaction instance</returns>
+        /// <returns>The generated Transaction instance</returns>
         Task<Transaction> OpenPositionWithLiquidity(
-            PublicKey positionMintAccount,
             PublicKey whirlpoolAddress,
+            PublicKey positionMintAccount,
             int tickLowerIndex,
             int tickUpperIndex,
-            BigInteger tokenMaxA,
-            BigInteger tokenMaxB,
+            BigInteger tokenAmountA,
+            BigInteger tokenAmountB,
+            double slippageTolerance = 0,
             bool withMetadata = false,
             PublicKey funderAccount = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
+        );
+
+        /// <summary> 
+        /// Constructs a single transaction to open a position, initialize tick arrays (if necessary), and add 
+        /// liquidity to the position, given a quote. 
+        /// </summary> 
+        /// <remarks> 
+        /// Signers: 
+        /// - funder
+        /// - positionMint
+        /// 
+        /// At minimum, the transaction may contain only a single instruction, to open the position (this 
+        /// would be if liquidity specified is zero). 
+        /// At most, the transaction would contain instructions to: 
+        /// - initialize lower tick array (if necessary)
+        /// - initialize upper tick array (if necessary) 
+        /// - open the position 
+        /// - add liquidity to the position 
+        /// </remarks> 
+        /// <param name="positionMintAccount"></param> 
+        /// <param name="whirlpoolAddress"></param> 
+        /// <param name="tickLowerIndex"></param> 
+        /// <param name="tickUpperIndex"></param>
+        /// <param name="increaseLiquidityQuote"></param>
+        /// <param name="withMetadata"></param> 
+        /// <param name="funderAccount"></param> 
+        /// <param name="commitment">Transaction commitment on which to base the transaction, and to use for 
+        /// any chain queries.</param> 
+        /// <returns>The generated Transaction instance</returns>
+        Task<Transaction> OpenPositionWithLiquidityWithQuote(
+            PublicKey whirlpoolAddress,
+            PublicKey positionMintAccount,
+            int tickLowerIndex,
+            int tickUpperIndex,
+            IncreaseLiquidityQuote increaseLiquidityQuote,
+            bool withMetadata = false,
+            PublicKey funderAccount = null,
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary> 
@@ -183,7 +225,7 @@ namespace Solana.Unity.Dex
             PublicKey positionAddress,
             PublicKey receiverAddress = null,
             PublicKey positionAuthority = null, 
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary> 
@@ -194,18 +236,40 @@ namespace Solana.Unity.Dex
         /// - positionAuthority
         /// </remarks>
         /// <param name="positionAddress">The unique position identifier.</param> 
-        /// <param name="tokenMaxA"></param> 
-        /// <param name="tokenMaxB"></param> 
+        /// <param name="tokenAmountA"></param> 
+        /// <param name="tokenAmountB"></param>
+        /// <param name="slippageTolerance"></param>
         /// <param name="positionAuthority"></param> 
         /// <param name="commitment">Transaction commitment on which to base the transaction, and to use for 
         /// any chain queries.</param> 
         /// <returns>The generated Transaction instance</returns>
         Task<Transaction> IncreaseLiquidity(
             PublicKey positionAddress,
-            BigInteger tokenMaxA,
-            BigInteger tokenMaxB,
+            BigInteger tokenAmountA,
+            BigInteger tokenAmountB,
+            double slippageTolerance = 0,
             PublicKey positionAuthority = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
+        );
+        
+        /// <summary> 
+        /// Constructs a transaction to add liquidity to an open position, given a quote. 
+        /// </summary> 
+        /// <remarks> 
+        /// Signers: 
+        /// - positionAuthority
+        /// </remarks>
+        /// <param name="positionAddress">The unique position identifier.</param> 
+        /// <param name="increaseLiquidityQuote"></param> 
+        /// <param name="positionAuthority"></param> 
+        /// <param name="commitment">Transaction commitment on which to base the transaction, and to use for 
+        /// any chain queries.</param> 
+        /// <returns>The generated Transaction instance</returns>
+        Task<Transaction> IncreaseLiquidityWithQuote(
+            PublicKey positionAddress,
+            IncreaseLiquidityQuote increaseLiquidityQuote,
+            PublicKey positionAuthority = null,
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary> 
@@ -229,23 +293,19 @@ namespace Solana.Unity.Dex
             BigInteger tokenMinA,
             BigInteger tokenMinB,
             PublicKey positionAuthority = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary> 
         /// Constructs a transaction to update fees and rewards for a given position. 
         /// </summary> 
         /// <param name="positionAddress">The unique position identifier.</param> 
-        /// <param name="tickArrayLower">Lower bounds tick array for the position.</param> 
-        /// <param name="tickArrayUpper">Upper bounds tick array of the position.</param> 
         /// <param name="commitment">Transaction commitment on which to base the transaction, and to use for 
         /// any chain queries.</param> 
         /// <returns>The generated Transaction instance</returns>
         Task<Transaction> UpdateFeesAndRewards(
             PublicKey positionAddress,
-            PublicKey tickArrayLower,
-            PublicKey tickArrayUpper,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary> 
@@ -263,7 +323,7 @@ namespace Solana.Unity.Dex
         Task<Transaction> CollectFees(
             PublicKey positionAddress,
             PublicKey positionAuthority = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary> 
@@ -274,8 +334,6 @@ namespace Solana.Unity.Dex
         /// - positionAuthority
         /// </remarks>
         /// <param name="positionAddress">The unique position identifier.</param> 
-        /// <param name="rewardMintAddress"></param> 
-        /// <param name="rewardVaultAddress"></param> 
         /// <param name="rewardIndex"></param> 
         /// <param name="positionAuthority"></param> 
         /// <param name="commitment">Transaction commitment on which to base the transaction, and to use for 
@@ -283,39 +341,29 @@ namespace Solana.Unity.Dex
         /// <returns>The generated Transaction instance</returns>
         Task<Transaction> CollectRewards(
             PublicKey positionAddress,
-            PublicKey rewardMintAddress,
-            PublicKey rewardVaultAddress,
             byte rewardIndex,
             PublicKey positionAuthority = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary> 
         /// Constructs a single transaction to update fees and rewards, and then collect fees. 
         /// </summary> 
         /// <param name="positionAddress">The unique position identifier.</param> 
-        /// <param name="tickArrayLower"></param> 
-        /// <param name="tickArrayUpper"></param> 
         /// <param name="positionAuthority"></param> 
         /// <param name="commitment">Transaction commitment on which to base the transaction, and to use for 
         /// any chain queries.</param> 
         /// <returns>The generated Transaction instance</returns>
         Task<Transaction> UpdateAndCollectFees(
             PublicKey positionAddress,
-            PublicKey tickArrayLower,
-            PublicKey tickArrayUpper,
             PublicKey positionAuthority = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary> 
         /// Constructs a single transaction to update fees and rewards, and then collect rewards. 
         /// </summary> 
         /// <param name="positionAddress">The unique position identifier.</param> 
-        /// <param name="tickArrayLower"></param> 
-        /// <param name="tickArrayUpper"></param> 
-        /// <param name="rewardMintAddress"></param> 
-        /// <param name="rewardVaultAddress"></param> 
         /// <param name="rewardIndex"></param> 
         /// <param name="positionAuthority"></param> 
         /// <param name="commitment">Transaction commitment on which to base the transaction, and to use for 
@@ -323,13 +371,9 @@ namespace Solana.Unity.Dex
         /// <returns>The generated Transaction instance</returns>
         Task<Transaction> UpdateAndCollectRewards(
             PublicKey positionAddress,
-            PublicKey tickArrayLower,
-            PublicKey tickArrayUpper,
-            PublicKey rewardMintAddress,
-            PublicKey rewardVaultAddress,
             byte rewardIndex,
             PublicKey positionAuthority = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary>
@@ -346,7 +390,7 @@ namespace Solana.Unity.Dex
             PublicKey tokenMintB,
             PublicKey configAccountAddress = null,
             ushort tickSpacing = TickSpacing.Standard,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
         );
         
         /// <summary>
@@ -363,17 +407,16 @@ namespace Solana.Unity.Dex
             PublicKey tokenMintB,
             ushort tickSpacing = TickSpacing.Standard,
             PublicKey configAccountAddress = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
         );
         
         /// <summary> 
-        /// Creates a quote for a swap within a specific whirlpool. 
+        /// Creates a quote for a swap for a specified pair of input/output token mint. 
         /// </summary> 
         /// <param name="inputTokenMintAddress">The mint address of the input token (the token to swap).</param> 
         /// <param name="outputTokenMintAddress">The mint address of the output token (the token to swap for).</param> 
         /// <param name="tokenAmount">The amount to swap (could be of the input token or output token).</param> 
         /// <param name="slippageTolerance"></param> 
-        /// <param name="amountSpecifiedTokenType"></param> 
         /// <param name="amountSpecifiedIsInput">True if the <paramref name="tokenAmount">tokenAmount</paramref> 
         /// refers to the input token.</param> 
         /// <param name="commitment">Transaction commitment on which to use for any chain queries.</param> 
@@ -383,9 +426,8 @@ namespace Solana.Unity.Dex
             PublicKey outputTokenMintAddress,
             BigInteger tokenAmount,
             double slippageTolerance = 0.01,
-            TokenType amountSpecifiedTokenType = TokenType.TokenA,
             bool amountSpecifiedIsInput = true,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary> 
@@ -395,7 +437,6 @@ namespace Solana.Unity.Dex
         /// <param name="inputTokenMintAddress">The mint address of the input token (the token to swap).</param> 
         /// <param name="tokenAmount">The amount to swap (could be of the input token or output token).</param> 
         /// <param name="slippageTolerance"></param> 
-        /// <param name="amountSpecifiedTokenType"></param> 
         /// <param name="amountSpecifiedIsInput">True if the <paramref name="tokenAmount">tokenAmount</paramref> 
         /// refers to the input token.</param> 
         /// <param name="commitment">Transaction commitment on which to use for any chain queries.</param> 
@@ -405,9 +446,8 @@ namespace Solana.Unity.Dex
             BigInteger tokenAmount,
             PublicKey inputTokenMintAddress,
             double slippageTolerance = 0.01,
-            TokenType amountSpecifiedTokenType = TokenType.TokenA,
             bool amountSpecifiedIsInput = true,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary> 
@@ -425,11 +465,11 @@ namespace Solana.Unity.Dex
         Task<IncreaseLiquidityQuote> GetIncreaseLiquidityQuote(
             PublicKey whirlpoolAddress,
             PublicKey inputTokenMintAddress,
-            double inputTokenAmount,
+            BigInteger inputTokenAmount,
             double slippageTolerance,
             int tickLowerIndex,
             int tickUpperIndex,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = Commitment.Finalized
         );
 
         /// <summary> 
@@ -445,7 +485,7 @@ namespace Solana.Unity.Dex
             PublicKey positionAddress,
             BigInteger liquidityAmount,
             double slippageTolerance,
-            Commitment commitment
+            Commitment? commitment = Commitment.Finalized
         );
         
         /// <summary>
@@ -460,5 +500,22 @@ namespace Solana.Unity.Dex
         /// <param name="symbol">the token symbol</param>
         /// <returns></returns>
         Task<TokenData> GetTokenBySymbol(string symbol);
+
+        /// <summary>
+        /// Get a token details given the mint address
+        /// </summary>
+        /// <param name="orcaMint"></param>
+        /// <returns></returns>
+        Task<TokenData> GetTokenByMint(string orcaMint);
+        
+        /// <summary>
+        /// Get the list of positions for a given owner
+        /// </summary>
+        /// <param name="owner"></param>
+        /// <param name="commitment"></param>
+        /// <returns></returns>
+        public abstract Task<IList<PublicKey>> GetPositions(
+            PublicKey owner = null,
+            Commitment? commitment = Commitment.Finalized);
     }
 }

--- a/src/Solana.Unity.Dex/Math/DecimalUtil.cs
+++ b/src/Solana.Unity.Dex/Math/DecimalUtil.cs
@@ -1,0 +1,26 @@
+using System.Numerics;
+
+namespace Solana.Unity.Dex.Math;
+
+public class DecimalUtil
+{
+    public static double FromUlong(ulong value, int shift = 0)
+    {
+        return value / System.Math.Pow(10, shift);
+    }
+    
+    public static double FromBigInteger(BigInteger value, int shift = 0)
+    {
+        return FromUlong((ulong)value, shift);
+    }
+    
+    public static ulong ToUlong(double value, int shift = 0)
+    {
+        return (ulong)(value * System.Math.Pow(10, shift));
+    }
+    
+    public static ulong ToUlong(float value, int shift = 0)
+    {
+        return ToUlong((double)value, shift);
+    }
+}

--- a/src/Solana.Unity.Dex/Models/Pool.cs
+++ b/src/Solana.Unity.Dex/Models/Pool.cs
@@ -1,0 +1,16 @@
+using Solana.Unity.Wallet;
+using System.Numerics;
+
+namespace Solana.Unity.Dex.Models;
+
+public class Pool
+{
+    public PublicKey Address { get; set; }
+    
+    public PublicKey TokenMintA { get; set; }
+    public PublicKey TokenMintB { get; set; }
+    
+    public BigInteger Liquidity { get; set; }
+    public ushort Fee { get; set; }
+    public ushort TickSpacing { get; set; }
+}

--- a/src/Solana.Unity.Dex/Orca/Math/SwapMath.cs
+++ b/src/Solana.Unity.Dex/Orca/Math/SwapMath.cs
@@ -127,8 +127,8 @@ namespace Solana.Unity.Dex.Orca.Math
         )
         {
             return (aToB == amountSpecifiedIsInput)
-                ? TokenMath.GetAmountDeltaB(currentSqrtPrice, targetSqrtPrice, currentLiquidity, amountSpecifiedIsInput)
-                : TokenMath.GetAmountDeltaA(currentSqrtPrice, targetSqrtPrice, currentLiquidity, amountSpecifiedIsInput);
+                ? TokenMath.GetAmountDeltaB(currentSqrtPrice, targetSqrtPrice, currentLiquidity, !amountSpecifiedIsInput)
+                : TokenMath.GetAmountDeltaA(currentSqrtPrice, targetSqrtPrice, currentLiquidity, !amountSpecifiedIsInput);
         }
     }
 }

--- a/src/Solana.Unity.Dex/Orca/Math/TokenMath.cs
+++ b/src/Solana.Unity.Dex/Orca/Math/TokenMath.cs
@@ -21,8 +21,8 @@ namespace Solana.Unity.Dex.Orca.Math
             BigInteger numerator = currentLiquidity * sqrtPriceDiff << 64;
             BigInteger denominator = sqrtPriceLower * sqrtPriceUpper;
 
-            BigInteger quotient = numerator / (denominator);
-            BigInteger remainder = numerator % (denominator);
+            BigInteger quotient = numerator / denominator;
+            BigInteger remainder = numerator % denominator;
 
             var result = roundUp && remainder != 0 ? quotient + BigInteger.One : quotient;
 
@@ -59,8 +59,8 @@ namespace Solana.Unity.Dex.Orca.Math
         )
         {
             return (sqrtPrice0 > sqrtPrice1) ? 
-                Tuple.Create<BigInteger, BigInteger>(sqrtPrice1, sqrtPrice0) : 
-                Tuple.Create<BigInteger, BigInteger>(sqrtPrice0, sqrtPrice1);
+                Tuple.Create(sqrtPrice1, sqrtPrice0) : 
+                Tuple.Create(sqrtPrice0, sqrtPrice1);
         }
 
         public static BigInteger GetNextSqrtPrice(
@@ -108,7 +108,7 @@ namespace Solana.Unity.Dex.Orca.Math
 
             BigInteger denominator = amountSpecifiedIsInput
                 ? currLiquidityShiftLeft + p
-                : currLiquidityShiftLeft + p;
+                : currLiquidityShiftLeft - p;
 
             BigInteger price = BitMath.DivRoundUp(numerator, denominator);
 

--- a/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs
+++ b/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs
@@ -17,9 +17,10 @@ using Solana.Unity.Dex.Orca.Quotes;
 using Solana.Unity.Dex.Orca.Ticks;
 using Solana.Unity.Dex.Orca.Quotes.Swap;
 using Solana.Unity.Dex.Orca.Core.Accounts;
+using Solana.Unity.Dex.Orca.Core.Types;
+using Solana.Unity.Dex.Orca.Math;
 using Solana.Unity.Dex.Orca.Orca;
 using Solana.Unity.Dex.Quotes;
-using Solana.Unity.Dex.Swap;
 using Solana.Unity.Dex.Ticks;
 
 namespace Orca
@@ -48,13 +49,13 @@ namespace Orca
             IRpcClient rpcClient, 
             IStreamingRpcClient streamingRpcClient = null, 
             PublicKey programId = null,
-            Commitment commitment = Commitment.Finalized) : this(
+            Commitment? commitment = null) : this(
             new WhirlpoolContext(
                 programId != null ? programId : AddressConstants.WHIRLPOOLS_PUBKEY,
                 rpcClient, 
                 streamingRpcClient, 
                 account, 
-                commitment)
+                commitment.GetValueOrDefault(Commitment.Finalized))
             ) { }
 
         /// <inheritdoc />
@@ -63,10 +64,10 @@ namespace Orca
             PublicKey whirlpoolAddress,
             BigInteger amount,
             PublicKey inputTokenMintAddress,
+            bool amountSpecifiedIsInput = true,
             double slippage = 0.01,
-            TokenType amountSpecifiedTokenType = TokenType.TokenA,
-            PublicKey tokenAuthority = null,
-            Commitment commitment = Commitment.Finalized
+            bool unwrapSol = true,
+            Commitment? commitment = null
         )
         {
             SwapQuote swapQuote = await GetSwapQuoteFromWhirlpool(
@@ -74,8 +75,9 @@ namespace Orca
                 amount, 
                 inputTokenMintAddress, 
                 slippage,
-                commitment: commitment);
-            return await SwapWithQuote(whirlpoolAddress, swapQuote);
+                amountSpecifiedIsInput,
+                commitment: commitment.GetValueOrDefault(DefaultCommitment));
+            return await SwapWithQuote(whirlpoolAddress, swapQuote, unwrapSol, commitment);
         }
         
         /// <inheritdoc />
@@ -83,26 +85,27 @@ namespace Orca
         public override async Task<Transaction> SwapWithQuote(
             PublicKey whirlpoolAddress,
             SwapQuote swapQuote,
-            Commitment commitment = Commitment.Finalized
+            bool unwrapSol = true,
+            Commitment? commitment = null
         )
         {
-            PublicKey account = _context.WalletPubKey; 
+            PublicKey account = Context.WalletPubKey; 
             
             // get the specified whirlpool
             Whirlpool whirlpool = await InstructionUtil.TryGetWhirlpoolAsync(
-                _context, whirlpoolAddress, commitment
+                Context, whirlpoolAddress, commitment.GetValueOrDefault(DefaultCommitment)
             );
 
             var tb = new TransactionBuilder();
 
             // instruction to create token account A 
             var ataA = await CreateAssociatedTokenAccountInstructionIfNotExtant(
-                account, whirlpool.TokenMintA, tb, commitment
+                account, whirlpool.TokenMintA, tb, commitment.GetValueOrDefault(DefaultCommitment)
             );
 
             // instruction to create token account B
             var ataB = await CreateAssociatedTokenAccountInstructionIfNotExtant(
-                account, whirlpool.TokenMintB, tb, commitment
+                account, whirlpool.TokenMintB, tb, commitment.GetValueOrDefault(DefaultCommitment)
             );
 
             // Wrap to wSOL if necessary
@@ -111,7 +114,7 @@ namespace Orca
                 SyncIfNative(account, whirlpool.TokenMintA, swapQuote.Amount, tb);
             }
             
-            if (whirlpool.TokenMintB.Equals(AddressConstants.NATIVE_MINT_PUBKEY) && swapQuote.AtoB)
+            if (whirlpool.TokenMintB.Equals(AddressConstants.NATIVE_MINT_PUBKEY) && !swapQuote.AtoB)
             {
                 SyncIfNative(account, whirlpool.TokenMintB, swapQuote.Amount, tb);
             }
@@ -119,14 +122,14 @@ namespace Orca
             //generate the transaction 
             tb.AddInstruction(
                 await OrcaInstruction.GenerateSwapInstruction(
-                    _context,
+                    Context,
                     whirlpool,
                     swapQuote
                 )
             );
             
             // Close wrapped sol account
-            if (whirlpool.TokenMintA.Equals(AddressConstants.NATIVE_MINT_PUBKEY))
+            if (unwrapSol && whirlpool.TokenMintA.Equals(AddressConstants.NATIVE_MINT_PUBKEY))
             {
                 tb.AddInstruction(TokenProgram.CloseAccount(
                     ataA,
@@ -137,7 +140,7 @@ namespace Orca
             }
             
             // Close wrapped sol account
-            if (whirlpool.TokenMintB.Equals(AddressConstants.NATIVE_MINT_PUBKEY))
+            if (unwrapSol && whirlpool.TokenMintB.Equals(AddressConstants.NATIVE_MINT_PUBKEY))
             {
                 tb.AddInstruction(TokenProgram.CloseAccount(
                     ataB,
@@ -148,7 +151,7 @@ namespace Orca
             }
 
             //set fee payer and recent blockhash 
-            return await PrepareTransaction(tb, account, RpcClient, commitment);
+            return await PrepareTransaction(tb, account, RpcClient, commitment.GetValueOrDefault(DefaultCommitment));
         }
 
         /// <inheritdoc />
@@ -161,16 +164,16 @@ namespace Orca
             int tickUpperIndex,
             bool withMetadata = false,
             PublicKey funderAccount = null, 
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
-            PublicKey account = _context.WalletPubKey;
+            PublicKey account = Context.WalletPubKey;
             
             //throw if whirlpool doesn't exist
-            await InstructionUtil.TryGetWhirlpoolAsync(_context, whirlpoolAddress, commitment);
+            await InstructionUtil.TryGetWhirlpoolAsync(Context, whirlpoolAddress, commitment.GetValueOrDefault(DefaultCommitment));
             
             //throw if position already exists 
-            if (await InstructionUtil.PositionExists(_context, positionMintAccount, commitment))
+            if (await InstructionUtil.PositionExists(Context, positionMintAccount, commitment.GetValueOrDefault(DefaultCommitment)))
                 throw new Exception($"A position for mint {positionMintAccount} on whirlpool {whirlpoolAddress} already exists");
 
             //funder defaults to account 
@@ -180,7 +183,7 @@ namespace Orca
             //generate the transaction 
             TransactionBuilder tb = new TransactionBuilder().AddInstruction(
                 OrcaInstruction.GenerateOpenPositionInstruction(
-                    _context,
+                    Context,
                     account,
                     funderAccount,
                     whirlpoolAddress,
@@ -192,7 +195,7 @@ namespace Orca
             );
 
             //set fee payer and recent blockhash 
-            return await PrepareTransaction(tb, account, this.RpcClient, commitment);
+            return await PrepareTransaction(tb, account, this.RpcClient, commitment.GetValueOrDefault(DefaultCommitment));
         }
 
         /// <inheritdoc />
@@ -204,7 +207,7 @@ namespace Orca
             int tickLowerIndex,
             int tickUpperIndex,
             PublicKey funderAccount = null, 
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
             return await OpenPosition(
@@ -225,27 +228,28 @@ namespace Orca
             PublicKey positionMintAddress,
             int tickLowerIndex,
             int tickUpperIndex,
-            BigInteger tokenMaxA,
-            BigInteger tokenMaxB,
+            BigInteger tokenAmountA,
+            BigInteger tokenAmountB,
+            double slippageTolerance = 0,
             bool withMetadata = false,
             PublicKey funderAccount = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
-            PublicKey account = _context.WalletPubKey;
+            PublicKey account = Context.WalletPubKey;
             
             //throw if position already exists 
-            if (await InstructionUtil.PositionExists(_context, positionMintAddress, commitment))
+            if (await InstructionUtil.PositionExists(Context, positionMintAddress, commitment.GetValueOrDefault(DefaultCommitment)))
                 throw new Exception($"A position for mint {positionMintAddress} on whirlpool {whirlpoolAddress} already exists");
 
             //throw if whirlpool doesn't exist 
-            Whirlpool whirlpool = await InstructionUtil.TryGetWhirlpoolAsync(_context, whirlpoolAddress, commitment); 
+            Whirlpool whirlpool = await InstructionUtil.TryGetWhirlpoolAsync(Context, whirlpoolAddress, commitment.GetValueOrDefault(DefaultCommitment)); 
             
-            TransactionBuilder tb = new TransactionBuilder();
+            TransactionBuilder tb = new();
 
             //need to initialize tick arrays? then do so
             int lowerStartTick = await CreateInitializeTickArrayInstructionIfNotExtant(
-                whirlpoolAddress, funderAccount, tickLowerIndex, whirlpool.TickSpacing, tb, commitment
+                whirlpoolAddress, funderAccount, tickLowerIndex, whirlpool.TickSpacing, tb, commitment.GetValueOrDefault(DefaultCommitment)
             );
             
             //only initialize the second one if different from the first 
@@ -253,14 +257,14 @@ namespace Orca
             if (upperStartTick != lowerStartTick) 
             {
                 await CreateInitializeTickArrayInstructionIfNotExtant(
-                    whirlpoolAddress, funderAccount, tickUpperIndex, whirlpool.TickSpacing, tb, commitment
+                    whirlpoolAddress, funderAccount, tickUpperIndex, whirlpool.TickSpacing, tb, commitment.GetValueOrDefault(DefaultCommitment)
                 );
             }
 
             //instruction to open position 
             tb.AddInstruction(
                 OrcaInstruction.GenerateOpenPositionInstruction(
-                    _context,
+                    Context,
                     account,
                     funderAccount,
                     whirlpoolAddress,
@@ -272,12 +276,19 @@ namespace Orca
             );
 
             //get position address 
-            Pda positionPda = PdaUtils.GetPosition(_context.ProgramId, positionMintAddress);
+            Pda positionPda = PdaUtils.GetPosition(Context.ProgramId, positionMintAddress);
+            
+            BigInteger tokenMaxA = TokenMath.AdjustForSlippage(
+                tokenAmountA, slippageTolerance, true
+            );
+            BigInteger tokenMaxB = TokenMath.AdjustForSlippage(
+                tokenAmountB, slippageTolerance, true
+            );
 
             //instruction to add liquidity 
             tb.AddInstruction(
                 await OrcaInstruction.GenerateIncreaseLiquidityInstruction(
-                    _context,
+                    Context,
                     ownerAccount: account,
                     whirlpoolAddress: whirlpoolAddress,
                     positionAddress: positionPda,
@@ -285,13 +296,93 @@ namespace Orca
                     positionAuthority: account,
                     tickLowerIndex: tickLowerIndex,
                     tickUpperIndex: tickUpperIndex,
+                    tokenAmountA: tokenAmountA,
+                    tokenAmountB: tokenAmountB,
                     tokenMaxA: tokenMaxA,
                     tokenMaxB: tokenMaxB,
-                    commitment: commitment
+                    commitment: commitment.GetValueOrDefault(DefaultCommitment)
                 )
             );
 
-            return await PrepareTransaction(tb, account, this.RpcClient, commitment);
+            return await PrepareTransaction(tb, account, RpcClient, commitment.GetValueOrDefault(DefaultCommitment));
+        }
+        
+        /// <inheritdoc />
+        /// <exception cref="System.Exception">Thrown if the specified whirlpool doesn't exist.</exception>
+        /// <exception cref="System.Exception">Thrown if the specified position already exists.</exception>
+        public override async Task<Transaction> OpenPositionWithLiquidityWithQuote(
+            PublicKey whirlpoolAddress,
+            PublicKey positionMintAddress,
+            int tickLowerIndex,
+            int tickUpperIndex,
+            IncreaseLiquidityQuote increaseLiquidityQuote,
+            bool withMetadata = false,
+            PublicKey funderAccount = null,
+            Commitment? commitment = null
+        )
+        {
+            PublicKey account = Context.WalletPubKey;
+            
+            //throw if position already exists 
+            if (await InstructionUtil.PositionExists(Context, positionMintAddress, commitment.GetValueOrDefault(DefaultCommitment)))
+                throw new Exception($"A position for mint {positionMintAddress} on whirlpool {whirlpoolAddress} already exists");
+
+            //throw if whirlpool doesn't exist 
+            Whirlpool whirlpool = await InstructionUtil.TryGetWhirlpoolAsync(Context, whirlpoolAddress, commitment.GetValueOrDefault(DefaultCommitment)); 
+            
+            TransactionBuilder tb = new();
+
+            //need to initialize tick arrays? then do so
+            int lowerStartTick = await CreateInitializeTickArrayInstructionIfNotExtant(
+                whirlpoolAddress, funderAccount, tickLowerIndex, whirlpool.TickSpacing, tb, commitment.GetValueOrDefault(DefaultCommitment)
+            );
+            
+            //only initialize the second one if different from the first 
+            int upperStartTick = TickUtils.GetStartTickIndex(tickUpperIndex, whirlpool.TickSpacing);
+            if (upperStartTick != lowerStartTick) 
+            {
+                await CreateInitializeTickArrayInstructionIfNotExtant(
+                    whirlpoolAddress, funderAccount, tickUpperIndex, whirlpool.TickSpacing, tb, commitment.GetValueOrDefault(DefaultCommitment)
+                );
+            }
+
+            //instruction to open position 
+            tb.AddInstruction(
+                OrcaInstruction.GenerateOpenPositionInstruction(
+                    Context,
+                    account,
+                    funderAccount,
+                    whirlpoolAddress,
+                    positionMintAddress,
+                    tickLowerIndex,
+                    tickUpperIndex,
+                    withMetadata
+                )
+            );
+
+            //get position address 
+            Pda positionPda = PdaUtils.GetPosition(Context.ProgramId, positionMintAddress);
+
+            //instruction to add liquidity 
+            tb.AddInstruction(
+                await OrcaInstruction.GenerateIncreaseLiquidityInstruction(
+                    Context,
+                    ownerAccount: account,
+                    whirlpoolAddress: whirlpoolAddress,
+                    positionAddress: positionPda,
+                    positionMintAddress: positionMintAddress,
+                    positionAuthority: account,
+                    tickLowerIndex: tickLowerIndex,
+                    tickUpperIndex: tickUpperIndex,
+                    tokenAmountA: increaseLiquidityQuote.TokenEstA,
+                    tokenAmountB: increaseLiquidityQuote.TokenEstB,
+                    tokenMaxA: increaseLiquidityQuote.TokenMaxA,
+                    tokenMaxB: increaseLiquidityQuote.TokenMaxB,
+                    commitment: commitment.GetValueOrDefault(DefaultCommitment)
+                )
+            );
+
+            return await PrepareTransaction(tb, account, RpcClient, commitment.GetValueOrDefault(DefaultCommitment));
         }
 
         /// <inheritdoc />
@@ -300,34 +391,85 @@ namespace Orca
             PublicKey positionAddress,
             PublicKey receiverAddress = null,
             PublicKey positionAuthority = null, 
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
-            PublicKey account = _context.WalletPubKey;
+            PublicKey account = Context.WalletPubKey;
             
             //receiver is the closer/owner if not otherwise specified 
             if (receiverAddress == null)
                 receiverAddress = account;
                 
             //retrieve the position 
-            Position position = await InstructionUtil.TryGetPositionAsync(_context, positionAddress, commitment);
+            Position position = await InstructionUtil.TryGetPositionAsync(
+                Context, 
+                positionAddress, 
+                commitment.GetValueOrDefault(DefaultCommitment));
+            
+            //retrieve the whirlpool
+            Whirlpool whirlpool = (await Context.WhirlpoolClient.GetWhirlpoolAsync(
+                    position.Whirlpool)).ParsedResult;
             
             //generate the transaction 
-            TransactionBuilder tb = new TransactionBuilder();
+            TransactionBuilder tb = new();
             
+            //add instruction to collect fees, if available
+            if (position.FeeOwedA > 0 || position.FeeOwedB > 0)
+            {
+                tb.AddInstruction(
+                    await OrcaInstruction.GenerateCollectFeesInstruction(
+                        Context,
+                        account,
+                        position,
+                        positionAddress,
+                        positionAuthority,
+                        commitment.GetValueOrDefault(DefaultCommitment)
+                    )
+                );
+            }
+            
+            //add instruction to collect rewards, if available
+            for (var rewardIndex = 0; rewardIndex < position.RewardInfos.Length; rewardIndex++)
+            {
+                if (position.RewardInfos[rewardIndex].AmountOwed > 0)
+                {
+                    //optional instruction to create reward token account (if it doesn't exist) 
+                    PublicKey rewardTokenOwnerAddress = await CreateAssociatedTokenAccountInstructionIfNotExtant(
+                        account, whirlpool.RewardInfos[rewardIndex].Mint, tb,
+                        commitment.GetValueOrDefault(DefaultCommitment)
+                    );
+
+                    //instruction to collect rewards 
+                    tb.AddInstruction(
+                        await OrcaInstruction.GenerateCollectRewardsInstruction(
+                            Context,
+                            account,
+                            position,
+                            positionAddress,
+                            whirlpool.RewardInfos[rewardIndex].Mint,
+                            whirlpool.RewardInfos[rewardIndex].Vault,
+                            rewardTokenOwnerAddress,
+                            positionAuthority,
+                            (byte)rewardIndex,
+                            commitment.GetValueOrDefault(DefaultCommitment)
+                        )
+                    );
+                }
+            }
+
             //add instruction to remove liquidity, if position has liquidity 
             if (position.Liquidity > 0) 
             {
                 tb.AddInstruction(
                     await OrcaInstruction.GenerateDecreaseLiquidityInstruction(
-                        _context, 
+                        Context, 
                         account,
                         position,
                         positionAddress,
                         positionAuthority,
                         position.Liquidity,
                         0, 0, 
-                        commitment
+                        commitment.GetValueOrDefault(DefaultCommitment)
                     )
                 );
             }
@@ -335,48 +477,90 @@ namespace Orca
             //close the position 
             tb.AddInstruction(
                 await OrcaInstruction.GenerateClosePositionInstruction(
-                    _context,
+                    Context,
                     account,
                     receiverAddress,
                     positionAddress,
                     positionAuthority,
-                    commitment
+                    commitment.GetValueOrDefault(DefaultCommitment)
                 )
             );
 
             //set fee payer and recent blockhash 
-            return await PrepareTransaction(tb, account, this.RpcClient, commitment);
+            return await PrepareTransaction(tb, account, this.RpcClient, commitment.GetValueOrDefault(DefaultCommitment));
         }
 
         /// <inheritdoc />
         /// <exception cref="System.Exception">Thrown if the specified position doesn't exist.</exception>
         public override async Task<Transaction> IncreaseLiquidity(
             PublicKey positionAddress,
-            BigInteger tokenMaxA, 
-            BigInteger tokenMaxB,
+            BigInteger tokenAmountA, 
+            BigInteger tokenAmountB,
+            double slippageTolerance = 0,
             PublicKey positionAuthority = null, 
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
-            PublicKey account = _context.WalletPubKey;
+            PublicKey account = Context.WalletPubKey;
             
             //throw if position doesn't exist 
-            Position position = await InstructionUtil.TryGetPositionAsync(_context, positionAddress, commitment);
+            Position position = await InstructionUtil.TryGetPositionAsync(Context, positionAddress, commitment.GetValueOrDefault(DefaultCommitment));
+            
+            BigInteger tokenMaxA = TokenMath.AdjustForSlippage(
+                tokenAmountA, slippageTolerance, true
+            );
+            BigInteger tokenMaxB = TokenMath.AdjustForSlippage(
+                tokenAmountB, slippageTolerance, true
+            );
 
             TransactionBuilder tb = new TransactionBuilder().AddInstruction(
                 await OrcaInstruction.GenerateIncreaseLiquidityInstruction(
-                    _context,
+                    Context,
                     account,
                     position,
                     positionAddress,
                     positionAuthority,
+                    tokenAmountA,
+                    tokenAmountB,
                     tokenMaxA,
                     tokenMaxB,
-                    commitment
+                    commitment.GetValueOrDefault(DefaultCommitment)
                 )
             );
             
-            return await PrepareTransaction(tb, account, this.RpcClient, commitment);
+            return await PrepareTransaction(tb, account, RpcClient, commitment.GetValueOrDefault(DefaultCommitment));
+        }
+        
+        /// <inheritdoc />
+        /// <exception cref="System.Exception">Thrown if the specified position doesn't exist.</exception>
+        public override async Task<Transaction> IncreaseLiquidityWithQuote(
+            PublicKey positionAddress,
+            IncreaseLiquidityQuote increaseLiquidityQuote,
+            PublicKey positionAuthority = null, 
+            Commitment? commitment = null
+        )
+        {
+            PublicKey account = Context.WalletPubKey;
+            
+            //throw if position doesn't exist 
+            Position position = await InstructionUtil.TryGetPositionAsync(Context, positionAddress, commitment.GetValueOrDefault(DefaultCommitment));
+
+            TransactionBuilder tb = new TransactionBuilder().AddInstruction(
+                await OrcaInstruction.GenerateIncreaseLiquidityInstruction(
+                    Context,
+                    account,
+                    position,
+                    positionAddress,
+                    positionAuthority,
+                    increaseLiquidityQuote.TokenEstA,
+                    increaseLiquidityQuote.TokenEstB,
+                    increaseLiquidityQuote.TokenMaxA,
+                    increaseLiquidityQuote.TokenMaxB,
+                    commitment.GetValueOrDefault(DefaultCommitment)
+                )
+            );
+            
+            return await PrepareTransaction(tb, account, RpcClient, commitment.GetValueOrDefault(DefaultCommitment));
         }
         
         /// <inheritdoc />
@@ -387,17 +571,17 @@ namespace Orca
             BigInteger tokenMinA, 
             BigInteger tokenMinB,
             PublicKey positionAuthority = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
-            PublicKey account = _context.WalletPubKey;
+            PublicKey account = Context.WalletPubKey;
             
             //throws if position doesn't exist 
-            Position position = await InstructionUtil.TryGetPositionAsync(_context, positionAddress, commitment);
+            Position position = await InstructionUtil.TryGetPositionAsync(Context, positionAddress, commitment.GetValueOrDefault(DefaultCommitment));
             
             TransactionBuilder tb = new TransactionBuilder().AddInstruction(
                 await OrcaInstruction.GenerateDecreaseLiquidityInstruction(
-                    _context,
+                    Context,
                     account,
                     position,
                     positionAddress,
@@ -405,39 +589,55 @@ namespace Orca
                     liquidityAmount,
                     tokenMinA, 
                     tokenMinB,
-                    commitment
+                    commitment.GetValueOrDefault(DefaultCommitment)
                 )
             );
 
-            return await PrepareTransaction(tb, account, this.RpcClient, commitment);
+            return await PrepareTransaction(tb, account, this.RpcClient, commitment.GetValueOrDefault(DefaultCommitment));
         }
 
         /// <inheritdoc />
         /// <exception cref="System.Exception">Thrown if the specified position doesn't exist.</exception>
         public override async Task<Transaction> UpdateFeesAndRewards(
             PublicKey positionAddress,
-            PublicKey tickArrayLower,
-            PublicKey tickArrayUpper, 
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
-            PublicKey account = _context.WalletPubKey; 
+            PublicKey account = Context.WalletPubKey; 
             
             //throws if whirlpool doesn't exist 
-            Position position = await InstructionUtil.TryGetPositionAsync(_context, positionAddress, commitment);
+            Position position = await InstructionUtil.TryGetPositionAsync(Context, positionAddress, commitment.GetValueOrDefault(DefaultCommitment));
+            
+            // get the specified whirlpool
+            Whirlpool whirlpool = await InstructionUtil.TryGetWhirlpoolAsync(
+                Context, position.Whirlpool, commitment.GetValueOrDefault(DefaultCommitment)
+            );
+            
+            // tick array addresses
+            Pda tickArrayLowerPda = PdaUtils.GetTickArray(
+                Context.ProgramId,
+                position.Whirlpool,
+                TickUtils.GetStartTickIndex(position.TickLowerIndex, whirlpool.TickSpacing)
+            );
+
+            Pda tickArrayUpperPda = PdaUtils.GetTickArray(
+                Context.ProgramId,
+                position.Whirlpool,
+                TickUtils.GetStartTickIndex(position.TickUpperIndex, whirlpool.TickSpacing)
+            );
             
             TransactionBuilder tb = new TransactionBuilder().AddInstruction(
                 OrcaInstruction.GenerateUpdateFeesAndRewardsInstruction(
-                    _context,
+                    Context,
                     position,
                     positionAddress,
-                    tickArrayLower,
-                    tickArrayUpper,
-                    commitment
+                    tickArrayLowerPda.PublicKey,
+                    tickArrayUpperPda.PublicKey,
+                    commitment.GetValueOrDefault(DefaultCommitment)
                 )
             );
 
-            return await PrepareTransaction(tb, account, this.RpcClient, commitment);
+            return await PrepareTransaction(tb, account, this.RpcClient, commitment.GetValueOrDefault(DefaultCommitment));
         }
 
         /// <inheritdoc />
@@ -445,163 +645,195 @@ namespace Orca
         public override async Task<Transaction> CollectFees(
             PublicKey positionAddress,
             PublicKey positionAuthority = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
-            PublicKey account = _context.WalletPubKey;
+            PublicKey account = Context.WalletPubKey;
 
             //throws if whirlpool doesn't exist 
-            Position position = await InstructionUtil.TryGetPositionAsync(_context, positionAddress, commitment);
+            Position position = await InstructionUtil.TryGetPositionAsync(Context, positionAddress, commitment.GetValueOrDefault(DefaultCommitment));
             
             TransactionBuilder tb = new TransactionBuilder().AddInstruction(
                 await OrcaInstruction.GenerateCollectFeesInstruction(
-                    _context,
+                    Context,
                     account,
                     position,
                     positionAddress,
                     positionAuthority,
-                    commitment
+                    commitment.GetValueOrDefault(DefaultCommitment)
                 )
             );
 
-            return await PrepareTransaction(tb, account, this.RpcClient, commitment);
+            return await PrepareTransaction(tb, account, this.RpcClient, commitment.GetValueOrDefault(DefaultCommitment));
         }
 
         /// <inheritdoc />
         /// <exception cref="System.Exception">Thrown if the specified position doesn't exist.</exception>
         public override async Task<Transaction> CollectRewards(
             PublicKey positionAddress,
-            PublicKey rewardMintAddress,
-            PublicKey rewardVaultAddress,
-            byte rewardIndex = 0,
+            byte rewardIndex,
             PublicKey positionAuthority = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
-            PublicKey account = _context.WalletPubKey;
+            PublicKey account = Context.WalletPubKey;
+            
+            Position position = await InstructionUtil.TryGetPositionAsync(Context, positionAddress, commitment.GetValueOrDefault(DefaultCommitment));
+            
+            // get the specified whirlpool
+            Whirlpool whirlpool = await InstructionUtil.TryGetWhirlpoolAsync(
+                Context, position.Whirlpool, commitment.GetValueOrDefault(DefaultCommitment)
+            );
 
-            //throws if whirlpool doesn't exist 
-            Position position = await InstructionUtil.TryGetPositionAsync(_context, positionAddress, commitment);
-
-            TransactionBuilder tb = new TransactionBuilder();
+            TransactionBuilder tb = new();
             
             //optional instruction to create reward token account (if it doesn't exist) 
             PublicKey rewardTokenOwnerAddress = await CreateAssociatedTokenAccountInstructionIfNotExtant(
-                account, rewardMintAddress, tb, commitment
+                account, whirlpool.RewardInfos[rewardIndex].Mint, tb, commitment.GetValueOrDefault(DefaultCommitment)
             ); 
             
             //instruction to collect rewards 
             tb.AddInstruction(
                 await OrcaInstruction.GenerateCollectRewardsInstruction(
-                    _context,
+                    Context,
                     account,
                     position,
                     positionAddress,
-                    rewardMintAddress, 
-                    rewardVaultAddress,
+                    whirlpool.RewardInfos[rewardIndex].Mint, 
+                    whirlpool.RewardInfos[rewardIndex].Vault,
                     rewardTokenOwnerAddress,
                     positionAuthority,
                     rewardIndex,
-                    commitment
+                    commitment.GetValueOrDefault(DefaultCommitment)
                 )
             );
 
-            return await PrepareTransaction(tb, account, this.RpcClient, commitment);
+            return await PrepareTransaction(tb, account, this.RpcClient, commitment.GetValueOrDefault(DefaultCommitment));
         }
 
         /// <inheritdoc />
         /// <exception cref="System.Exception">Thrown if the specified position doesn't exist.</exception>
         public override async Task<Transaction> UpdateAndCollectFees(
             PublicKey positionAddress,
-            PublicKey tickArrayLower,
-            PublicKey tickArrayUpper,
             PublicKey positionAuthority = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
-            PublicKey account = _context.WalletPubKey;
+            PublicKey account = Context.WalletPubKey;
 
             //throws if whirlpool doesn't exist 
-            Position position = await InstructionUtil.TryGetPositionAsync(_context, positionAddress, commitment);
+            Position position = await InstructionUtil.TryGetPositionAsync(Context, positionAddress, commitment.GetValueOrDefault(DefaultCommitment));
+            
+            // get the specified whirlpool
+            Whirlpool whirlpool = await InstructionUtil.TryGetWhirlpoolAsync(
+                Context, position.Whirlpool, commitment.GetValueOrDefault(DefaultCommitment)
+            );
+            
+            // tick array addresses
+            Pda tickArrayLower = PdaUtils.GetTickArray(
+                Context.ProgramId,
+                position.Whirlpool,
+                TickUtils.GetStartTickIndex(position.TickLowerIndex, whirlpool.TickSpacing)
+            );
+
+            Pda tickArrayUpper = PdaUtils.GetTickArray(
+                Context.ProgramId,
+                position.Whirlpool,
+                TickUtils.GetStartTickIndex(position.TickUpperIndex, whirlpool.TickSpacing)
+            );
 
             //instruction to udpate fees/rewards 
             TransactionBuilder tb = new TransactionBuilder().AddInstruction(
                 OrcaInstruction.GenerateUpdateFeesAndRewardsInstruction(
-                    _context,
+                    Context,
                     position,
                     positionAddress,
                     tickArrayLower,
                     tickArrayUpper,
-                    commitment
+                    commitment.GetValueOrDefault(DefaultCommitment)
                 )
                 
             //instruction to collect fees 
             ).AddInstruction(
                 await OrcaInstruction.GenerateCollectFeesInstruction(
-                    _context,
+                    Context,
                     account,
                     position, 
                     positionAddress,
                     positionAuthority,
-                    commitment
+                    commitment.GetValueOrDefault(DefaultCommitment)
                 )
             );
 
-            return await PrepareTransaction(tb, account, this.RpcClient, commitment);
+            return await PrepareTransaction(tb, account, this.RpcClient, commitment.GetValueOrDefault(DefaultCommitment));
         }
 
         /// <inheritdoc />
         /// <exception cref="System.Exception">Thrown if the specified position doesn't exist.</exception>
         public override async Task<Transaction> UpdateAndCollectRewards(
             PublicKey positionAddress,
-            PublicKey tickArrayLower,
-            PublicKey tickArrayUpper,
-            PublicKey rewardMintAddress,
-            PublicKey rewardVaultAddress,
-            byte rewardIndex = 0,
+            byte rewardIndex,
             PublicKey positionAuthority = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
-            PublicKey account = _context.WalletPubKey;
+            PublicKey account = Context.WalletPubKey;
 
             //throws if whirlpool doesn't exist 
-            Position position = await InstructionUtil.TryGetPositionAsync(_context, positionAddress, commitment);
+            Position position = await InstructionUtil.TryGetPositionAsync(Context, positionAddress, commitment.GetValueOrDefault(DefaultCommitment));
+            
+            // get the specified whirlpool
+            Whirlpool whirlpool = await InstructionUtil.TryGetWhirlpoolAsync(
+                Context, position.Whirlpool, commitment.GetValueOrDefault(DefaultCommitment)
+            );
+            
+            // tick array addresses
+            Pda tickArrayLower = PdaUtils.GetTickArray(
+                Context.ProgramId,
+                position.Whirlpool,
+                TickUtils.GetStartTickIndex(position.TickLowerIndex, whirlpool.TickSpacing)
+            );
+
+            Pda tickArrayUpper = PdaUtils.GetTickArray(
+                Context.ProgramId,
+                position.Whirlpool,
+                TickUtils.GetStartTickIndex(position.TickUpperIndex, whirlpool.TickSpacing)
+            );
 
             //instruction to update fees/rewards
             TransactionBuilder tb = new TransactionBuilder().AddInstruction(
                 OrcaInstruction.GenerateUpdateFeesAndRewardsInstruction(
-                    _context,
+                    Context,
                     position,
                     positionAddress,
                     tickArrayLower,
                     tickArrayUpper,
-                    commitment
+                    commitment.GetValueOrDefault(DefaultCommitment)
                 )
             );
 
             //optional instruction to create reward token account (if it doesn't exist) 
             PublicKey rewardTokenOwnerAddress = await CreateAssociatedTokenAccountInstructionIfNotExtant(
-                account, rewardMintAddress, tb, commitment
+                account, whirlpool.RewardInfos[rewardIndex].Mint, tb, commitment.GetValueOrDefault(DefaultCommitment)
             );
 
             //instruction to collect rewards
             tb.AddInstruction(
                 await OrcaInstruction.GenerateCollectRewardsInstruction(
-                    _context,
+                    Context,
                     account,
                     position,
                     positionAddress,
-                    rewardMintAddress, 
-                    rewardVaultAddress,
+                    whirlpool.RewardInfos[rewardIndex].Mint, 
+                    whirlpool.RewardInfos[rewardIndex].Vault,
                     rewardTokenOwnerAddress,
                     positionAuthority,
                     rewardIndex,
-                    commitment
+                    commitment.GetValueOrDefault(DefaultCommitment)
                 )
             );
 
-            return await PrepareTransaction(tb, account, this.RpcClient, commitment);
+            return await PrepareTransaction(tb, account, this.RpcClient, commitment.GetValueOrDefault(DefaultCommitment));
         }
 
         /// <inheritdoc />
@@ -610,20 +842,20 @@ namespace Orca
             PublicKey tokenMintB,
             PublicKey configAccountAddress = null,
             ushort tickSpacing = TickSpacing.Standard,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
             if (configAccountAddress == null) 
                 configAccountAddress = AddressConstants.WHIRLPOOLS_CONFIG_PUBKEY;
                 
             Pda whirlpoolPda = PdaUtils.GetWhirlpool(
-                _context.ProgramId,
+                Context.ProgramId,
                 configAccountAddress,
                 tokenMintA, tokenMintB, tickSpacing
             );
             
             //attempt to get whirlpool 
-            var whirlpoolResult = await _context.WhirlpoolClient.GetWhirlpoolAsync(whirlpoolPda.PublicKey, commitment); 
+            var whirlpoolResult = await Context.WhirlpoolClient.GetWhirlpoolAsync(whirlpoolPda.PublicKey, commitment); 
             
             //return true if whirlpool retrieved successfully
             return whirlpoolResult.WasSuccessful && whirlpoolResult.ParsedResult != null; 
@@ -635,7 +867,7 @@ namespace Orca
             PublicKey tokenMintB, 
             ushort tickSpacing = 128,
             PublicKey configAccountAddress = null, 
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
             var result = await TryFindWhirlpool(tokenMintA, tokenMintB, tickSpacing, configAccountAddress, commitment); 
@@ -643,6 +875,8 @@ namespace Orca
             if (result.Item2 == null) 
             {
                 var promises = new List<Task<Tuple<PublicKey, Whirlpool>>>(); 
+                
+                promises.Add(TryFindWhirlpool(tokenMintA, tokenMintB, 1, configAccountAddress, commitment));
                 
                 for (ushort ts = 8; ts <= 256; ts*=2) 
                 {
@@ -664,9 +898,11 @@ namespace Orca
         }
 
         /// <inheritdoc />
-        public override async Task<Whirlpool> GetWhirlpool(PublicKey whirlpoolAddress, Commitment commitment = Commitment.Finalized)
+        public override async Task<Whirlpool> GetWhirlpool(
+            PublicKey whirlpoolAddress, 
+            Commitment? commitment = null)
         {
-            return await InstructionUtil.TryGetWhirlpoolAsync(_context, whirlpoolAddress, commitment);
+            return await InstructionUtil.TryGetWhirlpoolAsync(Context, whirlpoolAddress, commitment.GetValueOrDefault(DefaultCommitment));
         }
 
         /// <inheritdoc />
@@ -676,20 +912,18 @@ namespace Orca
             BigInteger tokenAmount,
             PublicKey inputTokenMintAddress,
             double slippageTolerance = 0.01,
-            TokenType amountSpecifiedTokenType = TokenType.TokenA,
             bool amountSpecifiedIsInput = true
         )
         {
             return SwapQuoteUtils.SwapQuoteWithParams(
                 await SwapQuoteUtils.SwapQuoteByToken(
-                    _context,
+                    Context,
                     whirlpool,
                     whirlpool.Address,
                     inputTokenMintAddress,
                     tokenAmount,
-                    amountSpecifiedTokenType,
                     amountSpecifiedIsInput,
-                    _context.ProgramId
+                    Context.ProgramId
                 ),
                 slippageTolerance
             );
@@ -700,15 +934,15 @@ namespace Orca
         public override async Task<IncreaseLiquidityQuote> GetIncreaseLiquidityQuote(
             PublicKey whirlpoolAddress,
             PublicKey inputTokenMintAddress,
-            double inputTokenAmount,
+            BigInteger inputTokenAmount,
             double slippageTolerance,
             int tickLowerIndex,
             int tickUpperIndex,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
             //throws if whirlpool doesn't exist 
-            Whirlpool whirlpool = await InstructionUtil.TryGetWhirlpoolAsync(_context, whirlpoolAddress, commitment);
+            Whirlpool whirlpool = await InstructionUtil.TryGetWhirlpoolAsync(Context, whirlpoolAddress, commitment.GetValueOrDefault(DefaultCommitment));
 
             return IncreaseLiquidityQuoteUtils.GenerateIncreaseQuote(
                 inputTokenMintAddress,
@@ -726,12 +960,12 @@ namespace Orca
             PublicKey positionAddress,
             BigInteger liquidityAmount,
             double slippageTolerance,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
             //throws if whirlpool doesn't exist 
-            Position position = await InstructionUtil.TryGetPositionAsync(_context, positionAddress, commitment);
-            Whirlpool whirlpool = await InstructionUtil.TryGetWhirlpoolAsync(_context, position.Whirlpool, commitment);
+            Position position = await InstructionUtil.TryGetPositionAsync(Context, positionAddress, commitment.GetValueOrDefault(DefaultCommitment));
+            Whirlpool whirlpool = await InstructionUtil.TryGetWhirlpoolAsync(Context, position.Whirlpool, commitment.GetValueOrDefault(DefaultCommitment));
 
             return DecreaseLiquidityQuoteUtils.GenerateDecreaseQuote(
                 liquidityAmount,
@@ -739,6 +973,38 @@ namespace Orca
                 position,
                 whirlpool
             );
+        }
+
+        /// <inheritdoc />
+        public override async Task<IList<PublicKey>> GetPositions(
+            PublicKey owner = null, 
+            Commitment? commitment = null)
+        {
+            List<PublicKey> positions = new();
+            if (owner == null)
+                owner = Context.WalletPubKey;
+            var tokenAccountsRes = await Context.RpcClient.GetTokenAccountsByOwnerAsync(
+                owner, 
+                null,
+                TokenProgram.ProgramIdKey,
+                commitment: commitment.GetValueOrDefault(DefaultCommitment));
+            List<TokenAccount> tokenAccounts = tokenAccountsRes.Result.Value;
+
+            foreach (var tk in tokenAccounts)
+            {
+                var mint = tk.Account.Data.Parsed.Info.Mint;
+                var positionAddress = PdaUtils.GetPosition(Context.ProgramId, new PublicKey(mint));
+                try
+                {
+                    await InstructionUtil.TryGetPositionAsync(Context, positionAddress, commitment.GetValueOrDefault(DefaultCommitment));
+                    positions.Add(positionAddress);
+                }
+                catch (Exception e)
+                {
+                    // ignored
+                }
+            }
+            return positions;
         }
 
 
@@ -772,7 +1038,7 @@ namespace Orca
         )
         {
             bool exists = await InstructionUtil.AssociatedTokenAccountExists(
-                _context, ownerAddress, mintAddress, commitment
+                Context, ownerAddress, mintAddress, commitment
             );
             if (!exists)
             {
@@ -821,12 +1087,12 @@ namespace Orca
         {
             int startTickIndex = TickUtils.GetStartTickIndex(tickIndex, tickSpacing);
             if (!await InstructionUtil.TickArrayIsInitialized(
-                _context, whirlpoolAddress, startTickIndex, commitment)
+                Context, whirlpoolAddress, startTickIndex, commitment)
             )
             {
                 builder.AddInstruction(
                     OrcaInstruction.GenerateInitializeTickArrayInstruction(
-                        _context,
+                        Context,
                         whirlpoolAddress,
                         funderAccount,
                         startTickIndex,
@@ -846,7 +1112,7 @@ namespace Orca
             PublicKey tokenMintB,
             ushort tickSpacing,
             PublicKey configAccountAddress = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
             if (configAccountAddress == null)
@@ -854,7 +1120,7 @@ namespace Orca
 
             //get whirlpool address
             Pda whirlpoolPda = PdaUtils.GetWhirlpool(
-                _context.ProgramId,
+                Context.ProgramId,
                 configAccountAddress,
                 tokenMintA,
                 tokenMintB,
@@ -863,14 +1129,14 @@ namespace Orca
 
             //try to retrieve the whirlpool
             Whirlpool whirlpool = (
-                await _context.WhirlpoolClient.GetWhirlpoolAsync(whirlpoolPda.PublicKey.ToString(), commitment)
+                await Context.WhirlpoolClient.GetWhirlpoolAsync(whirlpoolPda.PublicKey.ToString(), commitment)
             ).ParsedResult;
 
             //if that didn't work, try to reverse the token mints
             if (whirlpool == null)
             {
                 Pda whirlpoolPdaAlt = PdaUtils.GetWhirlpool(
-                    _context.ProgramId,
+                    Context.ProgramId,
                     configAccountAddress,
                     tokenMintB,
                     tokenMintA,
@@ -879,7 +1145,7 @@ namespace Orca
 
                 //try to retrieve the whirlpool
                 whirlpool = (
-                    await _context.WhirlpoolClient.GetWhirlpoolAsync(whirlpoolPdaAlt.PublicKey.ToString(), commitment)
+                    await Context.WhirlpoolClient.GetWhirlpoolAsync(whirlpoolPdaAlt.PublicKey.ToString(), commitment)
                 ).ParsedResult;
 
                 //if that worked, return the alt address 

--- a/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs
+++ b/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs
@@ -404,7 +404,7 @@ namespace Orca
             
             //retrieve the whirlpool
             Whirlpool whirlpool = (await Context.WhirlpoolClient.GetWhirlpoolAsync(
-                    position.Whirlpool)).ParsedResult;
+                    position.Whirlpool, commitment.GetValueOrDefault(DefaultCommitment))).ParsedResult;
             
             //generate the transaction 
             TransactionBuilder tb = new();

--- a/src/Solana.Unity.Dex/Orca/Orca/OrcaInstruction.cs
+++ b/src/Solana.Unity.Dex/Orca/Orca/OrcaInstruction.cs
@@ -231,6 +231,8 @@ namespace Solana.Unity.Dex.Orca.Orca
         /// <param name="position">Object representing the position to which to add liquidity.</param>
         /// <param name="positionAddress">Address of the position to which to add liquidity.</param>
         /// <param name="positionAuthority">Optional; if null, it's the context's wallet public key.</param>
+        /// <param name="tokenAmountA">Desired liquidity for whirlpool's token A.</param>
+        /// <param name="tokenAmountB">Desired liquidity for whirlpool's token B.</param>
         /// <param name="tokenMaxA">Max liquidity for whirlpool's token A.</param>
         /// <param name="tokenMaxB">Max liquidity for whirlpool's token B.</param>
         /// <param name="commitment">Commitment to be used for any queries necessary to build the transaction.</param>
@@ -241,6 +243,8 @@ namespace Solana.Unity.Dex.Orca.Orca
             Position position,
             PublicKey positionAddress,
             PublicKey positionAuthority,
+            BigInteger tokenAmountA,
+            BigInteger tokenAmountB,
             BigInteger tokenMaxA,
             BigInteger tokenMaxB,
             Commitment commitment
@@ -255,6 +259,8 @@ namespace Solana.Unity.Dex.Orca.Orca
                 positionAuthority,
                 position.TickLowerIndex,
                 position.TickUpperIndex, 
+                tokenAmountA,
+                tokenAmountB,
                 tokenMaxA, 
                 tokenMaxB, 
                 commitment
@@ -272,6 +278,8 @@ namespace Solana.Unity.Dex.Orca.Orca
         /// <param name="positionAuthority"></param>
         /// <param name="tickLowerIndex"></param>
         /// <param name="tickUpperIndex"></param>
+        /// <param name="tokenAmountA"></param>
+        /// <param name="tokenAmountB"></param>
         /// <param name="tokenMaxA"></param>
         /// <param name="tokenMaxB"></param>
         /// <param name="commitment">Commitment to be used for any queries necessary to build the transaction.</param>
@@ -285,6 +293,8 @@ namespace Solana.Unity.Dex.Orca.Orca
             PublicKey positionAuthority,
             int tickLowerIndex, 
             int tickUpperIndex,
+            BigInteger tokenAmountA,
+            BigInteger tokenAmountB,
             BigInteger tokenMaxA,
             BigInteger tokenMaxB,
             Commitment commitment
@@ -317,7 +327,7 @@ namespace Solana.Unity.Dex.Orca.Orca
                 whirlpool.TickCurrentIndex,
                 tickLowerIndex,
                 tickUpperIndex,
-                TokenAmounts.FromValues(tokenMaxA, tokenMaxB)
+                TokenAmounts.FromValues(tokenAmountA, tokenAmountB)
             );
 
             //tickarray addresses

--- a/src/Solana.Unity.Dex/Orca/Quotes/IncreaseLiquidityQuoteUtils.cs
+++ b/src/Solana.Unity.Dex/Orca/Quotes/IncreaseLiquidityQuoteUtils.cs
@@ -16,7 +16,7 @@ namespace Solana.Unity.Dex.Orca.Quotes
     {
         public static IncreaseLiquidityQuote GenerateIncreaseQuote(
             PublicKey inputTokenMint,
-            BigDecimal inputTokenAmount,
+            BigInteger inputTokenAmount,
             int tickLower,
             int tickUpper, 
             Percentage slippageTolerance,
@@ -30,8 +30,7 @@ namespace Solana.Unity.Dex.Orca.Quotes
             return GenerateIncreaseQuoteWithParams(
                new IncreaseLiquidityQuoteParams{
                    InputTokenMint = inputMint,
-                   //TODO: (HIGH) see below 
-                   //InputTokenAmount = DecimalUtil.toU64(inputTokenAmount, inputTokenInfo.decimals), 
+                   InputTokenAmount = inputTokenAmount, 
                    TickCurrentIndex = whirlpool.TickCurrentIndex,
                    TickLowerIndex = TickUtils.GetInitializableTickIndex(tickLower, whirlpool.TickSpacing),
                    TickUpperIndex = TickUtils.GetInitializableTickIndex(tickUpper, whirlpool.TickSpacing),

--- a/src/Solana.Unity.Dex/Orca/Quotes/Swap/SwapQuoteUtils.cs
+++ b/src/Solana.Unity.Dex/Orca/Quotes/Swap/SwapQuoteUtils.cs
@@ -17,8 +17,18 @@ using Solana.Unity.Dex.Swap;
 
 namespace Solana.Unity.Dex.Orca.Quotes.Swap
 {
+    /// <summary>
+    /// Utility class for SwapQuote.
+    /// </summary>
     public static class SwapQuoteUtils
     {
+        /// <summary>
+        /// Checks if all the tick arrays have been initialized.
+        /// </summary>
+        /// <param name="tickArrays"></param>
+        /// <param name="throwException"></param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
         public static bool CheckIfAllTickArraysInitialized(IList<TickArrayContainer> tickArrays, bool throwException = true)
         {
             // Check if all the tick arrays have been initialized.
@@ -61,6 +71,17 @@ namespace Solana.Unity.Dex.Orca.Quotes.Swap
             return quote;
         }
         
+        /// <summary>
+        /// Returns a SwapQuote using the input token mint.
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="whirlpool"></param>
+        /// <param name="whirlpoolAddress"></param>
+        /// <param name="inputTokenMint"></param>
+        /// <param name="tokenAmount"></param>
+        /// <param name="slippageTolerance"></param>
+        /// <param name="programId"></param>
+        /// <returns></returns>
         public static async Task<SwapQuote> SwapQuoteByInputToken(
             IWhirlpoolContext ctx,
             Whirlpool whirlpool,
@@ -77,7 +98,6 @@ namespace Solana.Unity.Dex.Orca.Quotes.Swap
                 whirlpoolAddress,
                 inputTokenMint,
                 tokenAmount,
-                amountSpecifiedTokenType: TokenType.TokenA,
                 amountSpecifiedIsInput: true,
                 programId
             );
@@ -88,6 +108,17 @@ namespace Solana.Unity.Dex.Orca.Quotes.Swap
             );
         }
 
+        /// <summary>
+        /// Returns a SwapQuote using the output token mint.
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="whirlpool"></param>
+        /// <param name="whirlpoolAddress"></param>
+        /// <param name="outputTokenMint"></param>
+        /// <param name="tokenAmount"></param>
+        /// <param name="slippageTolerance"></param>
+        /// <param name="programId"></param>
+        /// <returns></returns>
         public static async Task<SwapQuote> SwapQuoteByOutputToken(
             IWhirlpoolContext ctx,
             Whirlpool whirlpool,
@@ -104,7 +135,6 @@ namespace Solana.Unity.Dex.Orca.Quotes.Swap
                     whirlpoolAddress,
                     outputTokenMint,
                     tokenAmount,
-                    amountSpecifiedTokenType: TokenType.TokenB,
                     amountSpecifiedIsInput: false,
                     programId
                 );
@@ -115,13 +145,24 @@ namespace Solana.Unity.Dex.Orca.Quotes.Swap
             );
         }
 
+        /// <summary>
+        /// Returns a SwapQuoteParam object that can be used to calculate a swap quote.
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="whirlpool"></param>
+        /// <param name="whirlpoolAddress"></param>
+        /// <param name="inputTokenMint"></param>
+        /// <param name="tokenAmount"></param>
+        /// <param name="amountSpecifiedIsInput"></param>
+        /// <param name="programId"></param>
+        /// <returns></returns>
+        /// <exception cref="WhirlpoolsException"></exception>
         public static async Task<SwapQuoteParam> SwapQuoteByToken(
             IWhirlpoolContext ctx,
             Whirlpool whirlpool,
             PublicKey whirlpoolAddress,
             PublicKey inputTokenMint,
             BigInteger tokenAmount,
-            TokenType amountSpecifiedTokenType,
             bool amountSpecifiedIsInput,
             PublicKey programId
         )
@@ -132,7 +173,7 @@ namespace Solana.Unity.Dex.Orca.Quotes.Swap
                     "swapTokenMint does not match any tokens on this pool",
                     SwapErrorCode.SqrtPriceOutOfBounds            
                 );
-            bool aToB = swapTokenType == amountSpecifiedTokenType;
+            bool aToB = inputTokenMint == whirlpool.TokenMintA;
 
             IList<TickArrayContainer> tickArrays = await SwapUtils.GetTickArrays(
                 ctx,
@@ -189,7 +230,7 @@ namespace Solana.Unity.Dex.Orca.Quotes.Swap
                 quoteParam.AtoB
             );
 
-            if (!tickSequence.CheckArrayContainsTickIndex(0, quoteParam.Whirlpool.TickCurrentIndex))
+            if (!tickSequence.IsValidTickArray0(quoteParam.Whirlpool.TickCurrentIndex))
             {
                 throw new WhirlpoolsException(
                     "TickArray at index 0 does not contain the Whirlpool current tick index.",

--- a/src/Solana.Unity.Dex/Orca/Swap/PoolUtils.cs
+++ b/src/Solana.Unity.Dex/Orca/Swap/PoolUtils.cs
@@ -27,7 +27,7 @@ namespace Solana.Unity.Dex.Orca.Swap
         /// These are the token mints that will be prioritized as the second token in the pair (quote).
         /// The number that the mint maps to determines the priority that it will be used as the quote currency.
         /// </summary>
-        public static readonly Dictionary<string, int> QuoteTokens = new Dictionary<string, int>()
+        public static readonly Dictionary<string, int> QuoteTokens = new()
         {
             { "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", 100},
             { "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", 90},
@@ -150,8 +150,8 @@ namespace Solana.Unity.Dex.Orca.Swap
         {
             return (GetQuoteTokenPriority(tokenMintAKey.ToString()) > 
                     GetQuoteTokenPriority(tokenMintBKey.ToString())) 
-                ? Tuple.Create<PublicKey, PublicKey>(tokenMintBKey, tokenMintAKey)
-                : Tuple.Create<PublicKey, PublicKey>(tokenMintAKey, tokenMintBKey);
+                ? Tuple.Create(tokenMintBKey, tokenMintAKey)
+                : Tuple.Create(tokenMintAKey, tokenMintBKey);
         }
 
         public static int GetQuoteTokenPriority(string mint)

--- a/src/Solana.Unity.Dex/Orca/Swap/SwapUtils.cs
+++ b/src/Solana.Unity.Dex/Orca/Swap/SwapUtils.cs
@@ -79,6 +79,7 @@ namespace Solana.Unity.Dex.Orca.Swap
             PublicKey whirlpoolAddress
         )
         {
+            int shift = aToB ? 0 : tickSpacing;
             int offset = 0;
             List<PublicKey> tickArrayAddresses = new List<PublicKey>();
             for (int n = 0; n < TickConstants.MAX_SWAP_TICK_ARRAYS; n++)
@@ -86,7 +87,7 @@ namespace Solana.Unity.Dex.Orca.Swap
                 int startIndex = 0;
                 try
                 {
-                    startIndex = TickUtils.GetStartTickIndex(tickCurrentIndex, tickSpacing, offset);
+                    startIndex = TickUtils.GetStartTickIndex(tickCurrentIndex + shift, tickSpacing, offset);
                 }
                 catch (Exception)
                 {

--- a/src/Solana.Unity.Dex/Orca/Swap/TokenAmounts.cs
+++ b/src/Solana.Unity.Dex/Orca/Swap/TokenAmounts.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Numerics;
-using System.Collections.Generic;
 
 namespace Solana.Unity.Dex.Orca.Swap
 {

--- a/src/Solana.Unity.Dex/Orca/Ticks/TickArraySequence.cs
+++ b/src/Solana.Unity.Dex/Orca/Ticks/TickArraySequence.cs
@@ -37,17 +37,27 @@ namespace Solana.Unity.Dex.Orca.Ticks
 
         public bool CheckArrayContainsTickIndex(int sequenceIndex, int tickIndex)
         {
-            TickArray data = this._tickArrays[sequenceIndex]?.Data;
+            TickArray data = _tickArrays[sequenceIndex]?.Data;
             if (data == null)
                 return false;
 
-            return this.CheckIfIndexIsInTickArrayRange(data.StartTickIndex, tickIndex);
+            return CheckIfIndexIsInTickArrayRange(data.StartTickIndex, tickIndex);
+        }
+        
+        public bool IsValidTickArray0(int tickIndex)
+        {
+            int shift = _aToB ? 0 : _tickSpacing;
+            TickArray data = _tickArrays[0]?.Data;
+            if (data == null)
+                return false;
+
+            return CheckIfIndexIsInTickArrayRange(data.StartTickIndex, tickIndex + shift);
         }
         
         public bool CheckIfIndexIsInTickArrayRange(int startTick, int tickIndex)
         {
-            int upperBound = startTick + this._tickSpacing * TickConstants.TICK_ARRAY_SIZE;
-            return !(tickIndex < startTick || tickIndex > upperBound);
+            int upperBound = startTick + _tickSpacing * TickConstants.TICK_ARRAY_SIZE;
+            return tickIndex >= startTick && tickIndex < upperBound;
         }
         
         /// <summary>

--- a/src/Solana.Unity.Dex/Orca/TxApi/Dex.cs
+++ b/src/Solana.Unity.Dex/Orca/TxApi/Dex.cs
@@ -11,7 +11,6 @@ using Solana.Unity.Rpc.Types;
 using Solana.Unity.Dex.Orca.Core;
 using Solana.Unity.Dex.Orca.Core.Accounts;
 using Solana.Unity.Dex.Quotes;
-using Solana.Unity.Dex.Swap;
 using Solana.Unity.Dex.Ticks;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,17 +22,35 @@ namespace Solana.Unity.Dex.Orca.TxApi
     /// </summary> 
     public abstract class Dex : IDex
     {
-        protected readonly IWhirlpoolContext _context;
+        /// <summary>
+        /// The whirlpool context object.
+        /// </summary>
+        protected readonly IWhirlpoolContext Context;
         
-        //Gets the RpcClient from the context object. 
-        protected IRpcClient RpcClient => _context.RpcClient;
         
-        //Gets the WhirlpoolClient from the context object. 
-        protected WhirlpoolClient WhirlpoolClient => _context.WhirlpoolClient;
+        /// <summary>
+        /// The default commitment level.
+        /// </summary>
+        protected readonly Commitment DefaultCommitment;
+        
+        /// <summary>
+        /// Gets the RpcClient from the context object.
+        /// </summary>
+        protected IRpcClient RpcClient => Context.RpcClient;
+        
+        /// <summary>
+        /// Gets the WhirlpoolClient from the context object.
+        /// </summary>
+        protected WhirlpoolClient WhirlpoolClient => Context.WhirlpoolClient;
 
+        /// <summary>
+        /// Create a new instance of Dex using the whirlpool context.
+        /// </summary>
+        /// <param name="context"></param>
         protected Dex(IWhirlpoolContext context)
         {
-            _context = context;
+            Context = context;
+            DefaultCommitment = Context.WhirlpoolClient.DefaultCommitment;
         }
 
         /// <inheritdoc />
@@ -41,51 +58,65 @@ namespace Solana.Unity.Dex.Orca.TxApi
             PublicKey whirlpoolAddress,
             BigInteger amount,
             PublicKey inputTokenMintAddress,
+            bool amountSpecifiedIsInput = true,
             double slippage = 0.01,
-            TokenType amountSpecifiedTokenType = TokenType.TokenA,
-            PublicKey tokenAuthority = null,
-            Commitment commitment = Commitment.Finalized
+            bool unwrapSol = true,
+            Commitment? commitment = null
         );
         
         /// <inheritdoc />
         public abstract Task<Transaction> SwapWithQuote(
             PublicKey whirlpoolAddress,
             SwapQuote swapQuote,
-            Commitment commitment = Commitment.Finalized
+            bool unwrapSol = true,
+            Commitment? commitment = null
         );
         
         /// <inheritdoc />
         public abstract Task<Transaction> OpenPosition(
-            PublicKey positionMintAccount,
             PublicKey whirlpoolAddress,
+            PublicKey positionMintAccount,
             int tickLowerIndex,
             int tickUpperIndex,
-            bool withMetadata,
-            PublicKey funderAccount,
-            Commitment commitment
+            bool withMetadata = false,
+            PublicKey funderAccount = null, 
+            Commitment? commitment = null
         );
 
         /// <inheritdoc />
         public abstract Task<Transaction> OpenPositionWithMetadata(
-            PublicKey positionMintAccount,
             PublicKey whirlpoolAddress,
+            PublicKey positionMintAccount,
             int tickLowerIndex,
             int tickUpperIndex,
-            PublicKey funderAccount,
-            Commitment commitment
+            PublicKey funderAccount = null, 
+            Commitment? commitment = null
         );
 
         /// <inheritdoc />
         public abstract Task<Transaction> OpenPositionWithLiquidity(
-            PublicKey positionMintAccount,
             PublicKey whirlpoolAddress,
+            PublicKey positionMintAccount,
             int tickLowerIndex,
             int tickUpperIndex,
-            BigInteger tokenMaxA,
-            BigInteger tokenMaxB,
+            BigInteger tokenAmountA,
+            BigInteger tokenAmountB,
+            double slippageTolerance = 0,
             bool withMetadata = false,
             PublicKey funderAccount = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
+        );
+        
+        /// <inheritdoc />
+        public abstract Task<Transaction> OpenPositionWithLiquidityWithQuote(
+            PublicKey whirlpoolAddress,
+            PublicKey positionMintAccount,
+            int tickLowerIndex,
+            int tickUpperIndex,
+            IncreaseLiquidityQuote increaseLiquidityQuote,
+            bool withMetadata = false,
+            PublicKey funderAccount = null,
+            Commitment? commitment = null
         );
         
         /// <inheritdoc />
@@ -93,16 +124,25 @@ namespace Solana.Unity.Dex.Orca.TxApi
             PublicKey positionAddress,
             PublicKey receiverAddress = null,
             PublicKey positionAuthority = null, 
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         );
 
         /// <inheritdoc />
         public abstract Task<Transaction> IncreaseLiquidity(
             PublicKey positionAddress,
-            BigInteger tokenMaxA, 
-            BigInteger tokenMaxB,
-            PublicKey positionAuthority,
-            Commitment commitment
+            BigInteger tokenAmountA, 
+            BigInteger tokenAmountB,
+            double slippageTolerance = 0,
+            PublicKey positionAuthority = null,
+            Commitment? commitment = null
+        );
+        
+        /// <inheritdoc />
+        public abstract Task<Transaction> IncreaseLiquidityWithQuote(
+            PublicKey positionAddress,
+            IncreaseLiquidityQuote increaseLiquidityQuote,
+            PublicKey positionAuthority = null,
+            Commitment? commitment = null
         );
         
         /// <inheritdoc />
@@ -111,54 +151,44 @@ namespace Solana.Unity.Dex.Orca.TxApi
             BigInteger liquidityAmount, 
             BigInteger tokenMinA, 
             BigInteger tokenMinB,
-            PublicKey positionAuthority,
-            Commitment commitment
+            PublicKey positionAuthority = null,
+            Commitment? commitment = null
         );
 
         /// <inheritdoc />
         public abstract Task<Transaction> UpdateFeesAndRewards(
             PublicKey positionAddress,
-            PublicKey tickArrayLower,
-            PublicKey tickArrayUpper,
-            Commitment commitment
+            Commitment? commitment = null
         );
 
         /// <inheritdoc />
         public abstract Task<Transaction> CollectFees(
             PublicKey positionAddress,
-            PublicKey positionAuthority,
-            Commitment commitment
+            PublicKey positionAuthority = null,
+            Commitment? commitment = null
         );
 
         /// <inheritdoc />
         public abstract Task<Transaction> CollectRewards(
             PublicKey positionAddress,
-            PublicKey rewardMintAddress,
-            PublicKey rewardVaultAddress,
             byte rewardIndex,
-            PublicKey positionAuthority,
-            Commitment commitment
+            PublicKey positionAuthority = null,
+            Commitment? commitment = null
         );
 
         /// <inheritdoc />
         public abstract Task<Transaction> UpdateAndCollectFees(
             PublicKey positionAddress,
-            PublicKey tickArrayLower,
-            PublicKey tickArrayUpper,
-            PublicKey positionAuthority,
-            Commitment commitment
+            PublicKey positionAuthority = null,
+            Commitment? commitment = null
         );
 
         /// <inheritdoc />
         public abstract Task<Transaction> UpdateAndCollectRewards(
             PublicKey positionAddress,
-            PublicKey tickArrayLower,
-            PublicKey tickArrayUpper,
-            PublicKey rewardMintAddress,
-            PublicKey rewardVaultAddress,
             byte rewardIndex,
-            PublicKey positionAuthority,
-            Commitment commitment
+            PublicKey positionAuthority = null,
+            Commitment? commitment = null
         );
 
         /// <inheritdoc />
@@ -167,7 +197,7 @@ namespace Solana.Unity.Dex.Orca.TxApi
             PublicKey tokenMintB,
             PublicKey configAccountAddress = null,
             ushort tickSpacing = TickSpacing.Standard,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         );
 
         /// <inheritdoc />
@@ -176,11 +206,11 @@ namespace Solana.Unity.Dex.Orca.TxApi
             PublicKey tokenMintB,
             ushort tickSpacing = TickSpacing.Standard,
             PublicKey configAccountAddress = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
-            (PublicKey whirlpollAddress, _) = await FindWhirlpool(tokenMintA, tokenMintB, tickSpacing, configAccountAddress, commitment);
-            return whirlpollAddress;
+            (PublicKey whirlpoolAddress, _) = await FindWhirlpool(tokenMintA, tokenMintB, tickSpacing, configAccountAddress, commitment);
+            return whirlpoolAddress;
         }
 
         /// <summary>
@@ -198,7 +228,7 @@ namespace Solana.Unity.Dex.Orca.TxApi
             PublicKey tokenMintB,
             ushort tickSpacing = TickSpacing.Standard,
             PublicKey configAccountAddress = null,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         );
         
         /// <summary>
@@ -209,7 +239,7 @@ namespace Solana.Unity.Dex.Orca.TxApi
         /// <returns></returns>
         public abstract Task<Whirlpool> GetWhirlpool(
             PublicKey whirlpoolAddress,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         );
 
         /// <inheritdoc />
@@ -218,9 +248,8 @@ namespace Solana.Unity.Dex.Orca.TxApi
             PublicKey outputTokenMintAddress,
             BigInteger tokenAmount,
             double slippageTolerance = 0.01,
-            TokenType amountSpecifiedTokenType = TokenType.TokenA,
             bool amountSpecifiedIsInput = true,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
             (PublicKey _, Whirlpool whrp)  = await FindWhirlpool(
@@ -231,8 +260,7 @@ namespace Solana.Unity.Dex.Orca.TxApi
                 whrp, 
                 tokenAmount, 
                 inputTokenMintAddress,
-                slippageTolerance, 
-                amountSpecifiedTokenType, 
+                slippageTolerance,
                 amountSpecifiedIsInput);
         }
 
@@ -242,9 +270,8 @@ namespace Solana.Unity.Dex.Orca.TxApi
             BigInteger tokenAmount,
             PublicKey inputTokenMintAddress,
             double slippageTolerance = 0.01,
-            TokenType amountSpecifiedTokenType = TokenType.TokenA,
             bool amountSpecifiedIsInput = true,
-            Commitment commitment = Commitment.Finalized
+            Commitment? commitment = null
         )
         {
             Whirlpool whrp = await GetWhirlpool(whirlpoolAddress, commitment);
@@ -252,8 +279,7 @@ namespace Solana.Unity.Dex.Orca.TxApi
                 whrp, 
                 tokenAmount, 
                 inputTokenMintAddress,
-                slippageTolerance, 
-                amountSpecifiedTokenType, 
+                slippageTolerance,
                 amountSpecifiedIsInput);
         }
 
@@ -265,7 +291,6 @@ namespace Solana.Unity.Dex.Orca.TxApi
         /// <param name="tokenAmount"></param>
         /// <param name="inputTokenMintAddress"></param>
         /// <param name="slippageTolerance"></param>
-        /// <param name="amountSpecifiedTokenType"></param>
         /// <param name="amountSpecifiedIsInput"></param>
         /// <returns></returns>
         public abstract Task<SwapQuote> GetSwapQuoteFromWhirlpool(
@@ -273,7 +298,6 @@ namespace Solana.Unity.Dex.Orca.TxApi
             BigInteger tokenAmount,
             PublicKey inputTokenMintAddress,
             double slippageTolerance = 0.01,
-            TokenType amountSpecifiedTokenType = TokenType.TokenA,
             bool amountSpecifiedIsInput = true
         );
 
@@ -281,11 +305,11 @@ namespace Solana.Unity.Dex.Orca.TxApi
         public abstract Task<IncreaseLiquidityQuote> GetIncreaseLiquidityQuote(
             PublicKey whirlpoolAddress,
             PublicKey inputTokenMintAddress,
-            double inputTokenAmount,
+            BigInteger inputTokenAmount,
             double slippageTolerance,
             int tickLowerIndex,
             int tickUpperIndex,
-            Commitment commitment
+            Commitment? commitment = null
         );
 
         /// <inheritdoc />
@@ -293,13 +317,18 @@ namespace Solana.Unity.Dex.Orca.TxApi
             PublicKey positionAddress,
             BigInteger liquidityAmount,
             double slippageTolerance,
-            Commitment commitment
+            Commitment? commitment = null
         );
+
+        /// <inheritdoc />
+        public abstract Task<IList<PublicKey>> GetPositions(
+            PublicKey owner = null,
+            Commitment? commitment = null);
 
         /// <inheritdoc />
         public async Task<IList<TokenData>> GetTokens()
         {
-            return await OrcaTokens.GetTokens(_context.RpcClient.NodeAddress.ToString().Contains("devnet") ? 
+            return await OrcaTokens.GetTokens(Context.RpcClient.NodeAddress.ToString().Contains("devnet") ? 
                 Cluster.DevNet : Cluster.MainNet );
         }
 
@@ -311,6 +340,15 @@ namespace Solana.Unity.Dex.Orca.TxApi
             return tokens.First(t => 
                 string.Equals(t.Symbol, symbol, StringComparison.CurrentCultureIgnoreCase) || 
                 string.Equals(t.Symbol, $"${symbol}", StringComparison.CurrentCultureIgnoreCase));
+        }
+        
+        /// <inheritdoc />
+        public async Task<TokenData> GetTokenByMint(string mint)
+        {
+            IList<TokenData> tokens = await GetTokens();
+            
+            return tokens.First(t => 
+                string.Equals(t.Mint, mint, StringComparison.CurrentCultureIgnoreCase));
         }
     }
 }

--- a/src/Solana.Unity.Dex/Orca/TxApi/Dex.cs
+++ b/src/Solana.Unity.Dex/Orca/TxApi/Dex.cs
@@ -196,21 +196,27 @@ namespace Solana.Unity.Dex.Orca.TxApi
             PublicKey tokenMintA,
             PublicKey tokenMintB,
             PublicKey configAccountAddress = null,
-            ushort tickSpacing = TickSpacing.Standard,
+            ushort tickSpacing = TickSpacing.HundredTwentyEight,
             Commitment? commitment = null
         );
 
         /// <inheritdoc />
-        public async Task<PublicKey> FindWhirlpoolAddress(
-            PublicKey tokenMintA,
+        public async Task<Pool> FindWhirlpoolAddress(PublicKey tokenMintA,
             PublicKey tokenMintB,
-            ushort tickSpacing = TickSpacing.Standard,
+            ushort tickSpacing = TickSpacing.HundredTwentyEight,
             PublicKey configAccountAddress = null,
-            Commitment? commitment = null
-        )
+            Commitment? commitment = Commitment.Finalized)
         {
-            (PublicKey whirlpoolAddress, _) = await FindWhirlpool(tokenMintA, tokenMintB, tickSpacing, configAccountAddress, commitment);
-            return whirlpoolAddress;
+            (PublicKey whirlpoolAddress, Whirlpool whirlpool) = await FindWhirlpool(tokenMintA, tokenMintB, tickSpacing, configAccountAddress, commitment);
+            return new Pool()
+            {
+                Address = whirlpoolAddress,
+                TokenMintA = whirlpool.TokenMintA,
+                TokenMintB = whirlpool.TokenMintB,
+                Liquidity = whirlpool.Liquidity,
+                Fee = whirlpool.FeeRate,
+                TickSpacing = whirlpool.TickSpacing,
+            };
         }
 
         /// <summary>
@@ -226,7 +232,7 @@ namespace Solana.Unity.Dex.Orca.TxApi
         public abstract Task<Tuple<PublicKey, Whirlpool>> FindWhirlpool(
             PublicKey tokenMintA,
             PublicKey tokenMintB,
-            ushort tickSpacing = TickSpacing.Standard,
+            ushort tickSpacing = TickSpacing.HundredTwentyEight,
             PublicKey configAccountAddress = null,
             Commitment? commitment = null
         );

--- a/src/Solana.Unity.Dex/Solana.Unity.Dex.csproj
+++ b/src/Solana.Unity.Dex/Solana.Unity.Dex.csproj
@@ -19,6 +19,6 @@
     
     <PropertyGroup>
     <Product>Solana.Unity.Dex</Product>
-    <Version>0.1</Version>
+    <Version>1.0</Version>
     </PropertyGroup>
 </Project>

--- a/src/Solana.Unity.Dex/Ticks/TickSpacing.cs
+++ b/src/Solana.Unity.Dex/Ticks/TickSpacing.cs
@@ -6,9 +6,9 @@ namespace Solana.Unity.Dex.Ticks
     public struct TickSpacing
     {
         public const ushort One = 1;
-        public const ushort Stable = 8;
+        public const ushort Eight = 8;
         public const ushort ThirtyTwo = 32;
         public const ushort SixtyFour = 64;
-        public const ushort Standard = 128;
+        public const ushort HundredTwentyEight = 128;
     }
 }

--- a/src/Solana.Unity.Programs/AssociatedTokenAccountProgram.cs
+++ b/src/Solana.Unity.Programs/AssociatedTokenAccountProgram.cs
@@ -37,8 +37,13 @@ namespace Solana.Unity.Programs
         /// <param name="payer">The public key of the account used to fund the associated token account.</param>
         /// <param name="owner">The public key of the owner account for the new associated token account.</param>
         /// <param name="mint">The public key of the mint for the new associated token account.</param>
+        /// <param name="idempotent">If creation is idempotent, won't fail if ata already exists</param>
         /// <returns>The transaction instruction, returns null whenever an associated token address could not be derived..</returns>
-        public static TransactionInstruction CreateAssociatedTokenAccount(PublicKey payer, PublicKey owner, PublicKey mint)
+        public static TransactionInstruction CreateAssociatedTokenAccount(
+            PublicKey payer, 
+            PublicKey owner,
+            PublicKey mint, 
+            bool idempotent = false)
         {
             PublicKey associatedTokenAddress = DeriveAssociatedTokenAccount(owner, mint);
 
@@ -59,7 +64,7 @@ namespace Solana.Unity.Programs
             {
                 ProgramId = ProgramIdKey.KeyBytes,
                 Keys = keys,
-                Data = Array.Empty<byte>()
+                Data = idempotent ? new byte[]{ 1 } : Array.Empty<byte>()
             };
         }
 

--- a/src/Solana.Unity.Wallet/PublicKey.cs
+++ b/src/Solana.Unity.Wallet/PublicKey.cs
@@ -21,6 +21,8 @@ namespace Solana.Unity.Wallet
         /// </summary>
         public const int PublicKeyLength = 32;
 
+        public static PublicKey DefaultPublicKey = new(new byte[PublicKeyLength]);
+        
         private string _key;
 
         /// <summary>

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/BigSwapTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/BigSwapTests.cs
@@ -53,7 +53,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
                 if (!tick.Initialized)
                     continue;
 
-                Console.WriteLine($"{tickArray.StartTickIndex + n * TickSpacing.Stable}: {tick.FeeGrowthOutsideA.ToString()}, {tick.FeeGrowthOutsideB.ToString()}");
+                Console.WriteLine($"{tickArray.StartTickIndex + n * TickSpacing.Eight}: {tick.FeeGrowthOutsideA.ToString()}, {tick.FeeGrowthOutsideB.ToString()}");
             }
         }
         
@@ -180,7 +180,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Stable,
+                tickSpacing: TickSpacing.Eight,
                 initSqrtPrice: PriceMath.TickIndexToSqrtPriceX64(27500)
             );
             
@@ -198,7 +198,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
                 whirlpool: whirlpoolPda,
                 27456, // to 30528
                 3,
-                TickSpacing.Stable,
+                TickSpacing.Eight,
                 aToB: false
             );
 
@@ -464,9 +464,6 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
 
             await DisplayTokenVaultBalances(poolInitResult);
             await DisplayTickArrays(tickArrays);
-
-            //collect protocol fees 
-            //TODO: (MID) implement collect protocol fees 
 
             await DisplayTokenVaultBalances(poolInitResult);
         }

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/CollectFeesTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/CollectFeesTests.cs
@@ -37,7 +37,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
         {
             int tickLowerIndex = 29440;
             int tickUpperIndex = 33536;
-            ushort tickSpacing = (ushort)TickSpacing.Standard;
+            ushort tickSpacing = (ushort)TickSpacing.HundredTwentyEight;
 
             WhirlpoolsTestFixture fixture = await WhirlpoolsTestFixture.CreateInstance(
                 _context,

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/CollectRewardsTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/CollectRewardsTests.cs
@@ -43,7 +43,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             BigInteger vaultStartBalance = 1_000_000;
             int lowerTickIndex = -1280;
             int upperTickIndex = 1280;
-            ushort tickSpacing = TickSpacing.Standard;
+            ushort tickSpacing = TickSpacing.HundredTwentyEight;
 
             WhirlpoolsTestFixture fixture = await WhirlpoolsTestFixture.CreateInstance(
                 _context,

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/DecreaseLiquidityTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/DecreaseLiquidityTests.cs
@@ -55,6 +55,12 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             );
 
             var testInfo = fixture.GetTestInfo();
+            
+            Position positionBefore = (await _context.WhirlpoolClient.GetPositionAsync(
+                testInfo.Positions[0].PublicKey,
+                _defaultCommitment
+            )).ParsedResult;
+            
             Whirlpool poolBefore = (await _context.WhirlpoolClient.GetWhirlpoolAsync(
                 testInfo.InitPoolParams.WhirlpoolPda.PublicKey,
                 Commitment.Processed
@@ -88,7 +94,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             Assert.IsTrue(await _context.RpcClient.ConfirmTransaction(result.Result));
 
             
-            BigInteger remainingLiquidity = liquidityAmount - removalQuote.LiquidityAmount;
+            BigInteger remainingLiquidity = positionBefore.Liquidity - removalQuote.LiquidityAmount;
 
             //position 
             Position position = (await _context.WhirlpoolClient.GetPositionAsync(

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/IncreaseLiquidityTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/IncreaseLiquidityTests.cs
@@ -236,7 +236,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             int currentTick = 500;
             int lowerTickIndex = 7168;
             int upperTickIndex = 8960;
-            ushort tickSpacing = TickSpacing.Standard;
+            ushort tickSpacing = TickSpacing.HundredTwentyEight;
 
             WhirlpoolsTestFixture fixture = await WhirlpoolsTestFixture.CreateInstance(
                 _context,
@@ -487,7 +487,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             int currTick = -443621;
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPool(
                 ctx: _context,
-                tickSpacing: TickSpacing.Stable,
+                tickSpacing: TickSpacing.Eight,
                 initSqrtPrice: PriceMath.TickIndexToSqrtPriceX64(currTick)
             );
 
@@ -575,7 +575,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             int currTick = 443635;
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPool(
                 ctx: _context,
-                tickSpacing: TickSpacing.Stable,
+                tickSpacing: TickSpacing.Eight,
                 initSqrtPrice: PriceMath.TickIndexToSqrtPriceX64(currTick)
             );
 
@@ -872,7 +872,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
 
             WhirlpoolsTestFixture fixture = await WhirlpoolsTestFixture.CreateInstance(
                 _context,
-                tickSpacing: TickSpacing.Standard,
+                tickSpacing: TickSpacing.HundredTwentyEight,
                 positions: new FundedPositionParams[]{
                     new()
                     {

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/InitializePoolTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/InitializePoolTests.cs
@@ -44,7 +44,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             var initFeeTierParams = FeeTierTestUtils.GenerateParams(
                 _context,
                 initConfigParams,
-                tickSpacing: TickSpacing.Standard
+                tickSpacing: TickSpacing.HundredTwentyEight
             );
             var initFeeTierResult = await FeeTierTestUtils.InitializeFeeTierAsync(
                 _context,
@@ -79,7 +79,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
                 initConfigParams.Accounts.Config,
                 tokenAMintAddr,
                 tokenBMintAddr,
-                TickSpacing.Standard
+                TickSpacing.HundredTwentyEight
             );
 
             Whirlpool whirlpool = (await _context.WhirlpoolClient.GetWhirlpoolAsync(

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/SwapTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/SwapTests.cs
@@ -45,7 +45,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Standard
+                tickSpacing: TickSpacing.HundredTwentyEight
             );
             
             Assert.IsTrue(poolInitResult.WasSuccessful);
@@ -163,7 +163,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                TickSpacing.Stable,
+                TickSpacing.Eight,
                 initSqrtPrice: PriceMath.TickIndexToSqrtPriceX64(27500)
             );
             
@@ -175,7 +175,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
                 whirlpool: whirlpoolPda,
                 startTickIndex: 27456,
                 arrayCount: 5, 
-                tickSpacing: TickSpacing.Stable
+                tickSpacing: TickSpacing.Eight
             );
 
             //generate fund params 
@@ -270,14 +270,14 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context, 
                 ConfigTestUtils.GenerateParams( _context),
-                TickSpacing.Standard
+                TickSpacing.HundredTwentyEight
             );
 
             //initialize another test pool 
             PoolInitResult anotherPoolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                TickSpacing.Standard
+                TickSpacing.HundredTwentyEight
             );
             
             Pda whirlpoolPda = poolInitResult.InitPoolParams.WhirlpoolPda;
@@ -323,14 +323,14 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                TickSpacing.Standard
+                TickSpacing.HundredTwentyEight
             );
 
             //initialize another test pool 
             PoolInitResult anotherPoolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                TickSpacing.Standard
+                TickSpacing.HundredTwentyEight
             );
 
             Pda whirlpoolPda = poolInitResult.InitPoolParams.WhirlpoolPda;
@@ -376,14 +376,14 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                TickSpacing.Standard
+                TickSpacing.HundredTwentyEight
             );
 
             //initialize another test pool 
             PoolInitResult anotherPoolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                TickSpacing.Stable
+                TickSpacing.Eight
             );
 
             Pda whirlpoolPda = poolInitResult.InitPoolParams.WhirlpoolPda;
@@ -429,14 +429,14 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                TickSpacing.Standard
+                TickSpacing.HundredTwentyEight
             );
 
             //initialize another test pool 
             PoolInitResult anotherPoolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                TickSpacing.Stable
+                TickSpacing.Eight
             );
 
             Pda whirlpoolPda = poolInitResult.InitPoolParams.WhirlpoolPda;
@@ -482,7 +482,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                TickSpacing.Standard
+                TickSpacing.HundredTwentyEight
             );
 
             Pda whirlpoolPda = poolInitResult.InitPoolParams.WhirlpoolPda;
@@ -536,7 +536,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Standard,
+                tickSpacing: TickSpacing.HundredTwentyEight,
                 initSqrtPrice: ArithmeticUtils.DecimalToX64BigInt(new BigDecimal(0.0242).Sqrt())
             );
 
@@ -581,14 +581,14 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Standard
+                tickSpacing: TickSpacing.HundredTwentyEight
             );
             
             //initialize test pool 
             PoolInitResult anotherPoolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Standard
+                tickSpacing: TickSpacing.HundredTwentyEight
             );
 
             Pda whirlpoolPda = poolInitResult.InitPoolParams.WhirlpoolPda;
@@ -633,14 +633,14 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Standard
+                tickSpacing: TickSpacing.HundredTwentyEight
             );
 
             //initialize test pool 
             PoolInitResult anotherPoolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Standard
+                tickSpacing: TickSpacing.HundredTwentyEight
             );
 
             Pda whirlpoolPda = poolInitResult.InitPoolParams.WhirlpoolPda;
@@ -685,7 +685,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Standard
+                tickSpacing: TickSpacing.HundredTwentyEight
             );
 
             Pda whirlpoolPda = poolInitResult.InitPoolParams.WhirlpoolPda;
@@ -724,14 +724,14 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Standard
+                tickSpacing: TickSpacing.HundredTwentyEight
             );
 
             //initialize test pool 
             PoolInitResult anotherPoolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Standard
+                tickSpacing: TickSpacing.HundredTwentyEight
             );
 
             Pda whirlpoolPda = poolInitResult.InitPoolParams.WhirlpoolPda;
@@ -775,7 +775,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Standard
+                tickSpacing: TickSpacing.HundredTwentyEight
             );
 
             Pda whirlpoolPda = poolInitResult.InitPoolParams.WhirlpoolPda;
@@ -926,7 +926,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Standard
+                tickSpacing: TickSpacing.HundredTwentyEight
             );
 
             Pda whirlpoolPda = poolInitResult.InitPoolParams.WhirlpoolPda;
@@ -990,7 +990,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Standard
+                tickSpacing: TickSpacing.HundredTwentyEight
             );
 
             Pda whirlpoolPda = poolInitResult.InitPoolParams.WhirlpoolPda;
@@ -1051,7 +1051,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Standard
+                tickSpacing: TickSpacing.HundredTwentyEight
             );
 
             Pda whirlpoolPda = poolInitResult.InitPoolParams.WhirlpoolPda;
@@ -1110,7 +1110,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPoolWithTokens(
                 _context,
                 ConfigTestUtils.GenerateParams(_context),
-                tickSpacing: TickSpacing.Standard
+                tickSpacing: TickSpacing.HundredTwentyEight
             );
 
             Pda whirlpoolPda = poolInitResult.InitPoolParams.WhirlpoolPda;

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/SwapTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/SwapTests.cs
@@ -204,8 +204,6 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             await PositionTestUtils.FundPositionsAsync(
                 _context,
                 poolInitResult.InitPoolParams,
-                poolInitResult.TokenAccountA,
-                poolInitResult.TokenAccountB,
                 fundParams
             );
 
@@ -952,9 +950,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             //fund positions 
             await PositionTestUtils.FundPositionsAsync(
                 _context, 
-                poolInitResult.InitPoolParams, 
-                poolInitResult.TokenAccountA,
-                poolInitResult.TokenAccountB,
+                poolInitResult.InitPoolParams,
                 fundParams
             );
             
@@ -1016,8 +1012,6 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             await PositionTestUtils.FundPositionsAsync(
                 _context,
                 poolInitResult.InitPoolParams,
-                poolInitResult.TokenAccountA,
-                poolInitResult.TokenAccountB,
                 fundParams
             );
 
@@ -1077,8 +1071,6 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             await PositionTestUtils.FundPositionsAsync(
                 _context,
                 poolInitResult.InitPoolParams,
-                poolInitResult.TokenAccountA,
-                poolInitResult.TokenAccountB,
                 fundParams
             );
 
@@ -1137,8 +1129,6 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             await PositionTestUtils.FundPositionsAsync(
                 _context,
                 poolInitResult.InitPoolParams,
-                poolInitResult.TokenAccountA,
-                poolInitResult.TokenAccountB,
                 fundParams
             );
 

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/ClosePositionTxApiTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/ClosePositionTxApiTests.cs
@@ -82,7 +82,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             Account positionMintAccount = new Account();
             Pda positionPda = PdaUtils.GetPosition(_context.ProgramId, positionMintAccount.PublicKey);
 
-            //get the transaction toopen the position 
+            //get the transaction to open the position 
             Transaction tx;
             if (liquidityAmount > 0)
             {

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/CollectFeesTxApiTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/CollectFeesTxApiTests.cs
@@ -89,16 +89,12 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
         
         private static async Task UpdateFeesAndRewards(
             IDex dex,
-            PublicKey positionAddress,
-            PublicKey tickArrayLower, 
-            PublicKey tickArrayUpper
+            PublicKey positionAddress
         ) 
         {
             //get transaction 
             Transaction tx = await dex.UpdateFeesAndRewards(
-                positionAddress, 
-                tickArrayLower, 
-                tickArrayUpper,
+                positionAddress,
                 commitment: TestConfiguration.DefaultCommitment
             );
 
@@ -142,7 +138,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
 
             //update fees and rewards 
             await UpdateFeesAndRewards(
-                dex, position.PublicKey, tickArrayPda, tickArrayPda
+                dex, position.PublicKey
             );
 
             //get position before fee collection

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/CollectFeesTxApiTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/CollectFeesTxApiTests.cs
@@ -231,7 +231,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             Assert.That(positionBeforeCollect.FeeOwedB, Is.EqualTo(581));
             
             //close Atas
-            Assert.IsTrue(whirlpool.TokenMintA.ToString().Equals(AddressConstants.NATIVE_MINT));
+            Assert.IsTrue(whirlpool.TokenMintA.Equals(AddressConstants.NATIVE_MINT_PUBKEY));
             await TokenUtils.CloseAta(_context.RpcClient, whirlpool.TokenMintA, _context.WalletAccount, _context.WalletAccount);
             await TokenUtils.CloseAta(_context.RpcClient, whirlpool.TokenMintB, _context.WalletAccount, _context.WalletAccount);
 

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/CollectRewardsTxApiTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/CollectRewardsTxApiTests.cs
@@ -77,8 +77,6 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             //get transaction 
             Transaction tx = await dex.UpdateFeesAndRewards(
                 positionAddress,
-                tickArrayLower,
-                tickArrayUpper,
                 commitment: TestConfiguration.DefaultCommitment
             );
 
@@ -105,8 +103,6 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             //generate a transaction 
             Transaction tx = await dex.CollectRewards(
                 testInfo.Positions[0].PublicKey,
-                testInfo.Rewards[rewardIndex].RewardMint,
-                testInfo.Rewards[rewardIndex].RewardVaultKeyPair.PublicKey, 
                 rewardIndex,
                 commitment: TestConfiguration.DefaultCommitment
             );

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/DecreaseLiquidityTxApiTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/DecreaseLiquidityTxApiTests.cs
@@ -66,6 +66,12 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             Whirlpool poolBefore = (
                 await _context.WhirlpoolClient.GetWhirlpoolAsync(whirlpoolPda.PublicKey, Commitment.Processed)
             ).ParsedResult;
+            
+            //position 
+            Position positionBefore = (await _context.WhirlpoolClient.GetPositionAsync(
+                testInfo.Positions[0].PublicKey.ToString(),
+                _defaultCommitment
+            )).ParsedResult;
 
             //generate liquidity removal quote
             DecreaseLiquidityQuote removalQuote = DecreaseLiquidityQuoteUtils.GenerateDecreaseQuoteWithParams(
@@ -99,11 +105,12 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             Assert.IsTrue(decreaseResult.WasSuccessful);
             Assert.IsTrue(await _context.RpcClient.ConfirmTransaction(decreaseResult.Result, _defaultCommitment));
 
-            BigInteger remainingLiquidity = liquidityAmount - removalQuote.LiquidityAmount;
+            BigInteger remainingLiquidity = positionBefore.Liquidity - removalQuote.LiquidityAmount;
 
             //position 
             Position position = (await _context.WhirlpoolClient.GetPositionAsync(
-                testInfo.Positions[0].PublicKey.ToString()
+                testInfo.Positions[0].PublicKey.ToString(),
+                _defaultCommitment
             )).ParsedResult;
 
             Assert.NotNull(position);
@@ -147,6 +154,12 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             await TokenUtils.CloseAta(_context.RpcClient, poolBefore.TokenMintA, _context.WalletAccount, _context.WalletAccount);
             await TokenUtils.CloseAta(_context.RpcClient, poolBefore.TokenMintB, _context.WalletAccount, _context.WalletAccount);
 
+            //position 
+            Position positionBefore = (await _context.WhirlpoolClient.GetPositionAsync(
+                testInfo.Positions[0].PublicKey.ToString(),
+                _defaultCommitment
+            )).ParsedResult;
+            
             //generate liquidity removal quote
             DecreaseLiquidityQuote removalQuote = DecreaseLiquidityQuoteUtils.GenerateDecreaseQuoteWithParams(
                 new DecreaseLiquidityQuoteParams
@@ -179,11 +192,12 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             Assert.IsTrue(decreaseResult.WasSuccessful);
             Assert.IsTrue(await _context.RpcClient.ConfirmTransaction(decreaseResult.Result, _defaultCommitment));
 
-            BigInteger remainingLiquidity = liquidityAmount - removalQuote.LiquidityAmount;
+            BigInteger remainingLiquidity = positionBefore.Liquidity - removalQuote.LiquidityAmount;
 
             //position 
             Position position = (await _context.WhirlpoolClient.GetPositionAsync(
-                testInfo.Positions[0].PublicKey.ToString()
+                testInfo.Positions[0].PublicKey.ToString(),
+                _defaultCommitment
             )).ParsedResult;
 
             Assert.NotNull(position);
@@ -191,7 +205,8 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
 
             //ticks
             TickArray tickArray = (await _context.WhirlpoolClient.GetTickArrayAsync(
-                testInfo.Positions[0].TickArrayLower
+                testInfo.Positions[0].TickArrayLower,
+                _defaultCommitment
             )).ParsedResult;
 
             AssertUtils.AssertTick(tickArray.Ticks[56], true, remainingLiquidity, remainingLiquidity);

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/FindWhirlpoolTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/FindWhirlpoolTests.cs
@@ -90,14 +90,14 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             var (address, wp) = await dex.FindWhirlpool(
                 _tokenPairs[0].Item1,
                 _tokenPairs[0].Item2,
-                TickSpacing.Standard,
+                TickSpacing.HundredTwentyEight,
                 _whirlpoolConfigAddress,
                 TestConfiguration.DefaultCommitment
             );
             Assert.IsNotNull(wp);
             Assert.That(wp.TokenMintA, Is.EqualTo(_tokenPairs[0].Item1));
             Assert.That(wp.TokenMintB, Is.EqualTo(_tokenPairs[0].Item2));
-            Assert.That(wp.TickSpacing, Is.EqualTo(TickSpacing.Standard));
+            Assert.That(wp.TickSpacing, Is.EqualTo(TickSpacing.HundredTwentyEight));
             Assert.That(wp.Address, Is.EqualTo(address));
         }
         
@@ -110,11 +110,15 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             var address = await dex.FindWhirlpoolAddress(
                 _tokenPairs[0].Item1,
                 _tokenPairs[0].Item2,
-                TickSpacing.Standard,
+                TickSpacing.HundredTwentyEight,
                 _whirlpoolConfigAddress,
                 TestConfiguration.DefaultCommitment
             );
             Assert.IsNotNull(address);
+            Assert.IsNotNull(address.TokenMintA);
+            Assert.IsNotNull(address.TokenMintB);
+            Assert.IsNotNull(address.Liquidity);
+            Assert.IsNotNull(address.Fee);
         }
 
         [Test]
@@ -127,14 +131,14 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             var (address, wp) = await dex.FindWhirlpool(
                 _tokenPairs[0].Item1,
                 _tokenPairs[0].Item2,
-                TickSpacing.Stable,
+                TickSpacing.Eight,
                 _whirlpoolConfigAddress,
                 TestConfiguration.DefaultCommitment
             );
             Assert.IsNotNull(wp);
             Assert.That(wp.TokenMintA, Is.EqualTo(_tokenPairs[0].Item1));
             Assert.That(wp.TokenMintB, Is.EqualTo(_tokenPairs[0].Item2));
-            Assert.That(wp.TickSpacing, Is.EqualTo(TickSpacing.Standard));
+            Assert.That(wp.TickSpacing, Is.EqualTo(TickSpacing.HundredTwentyEight));
             Assert.That(wp.Address, Is.EqualTo(address));
         }
 
@@ -147,14 +151,14 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             var (address, wp) = await dex.FindWhirlpool(
                 _tokenPairs[0].Item2,
                 _tokenPairs[0].Item1,
-                TickSpacing.Standard,
+                TickSpacing.HundredTwentyEight,
                 _whirlpoolConfigAddress,
                 TestConfiguration.DefaultCommitment
             );
             Assert.IsNotNull(wp);
             Assert.That(wp.TokenMintA, Is.EqualTo(_tokenPairs[0].Item1));
             Assert.That(wp.TokenMintB, Is.EqualTo(_tokenPairs[0].Item2));
-            Assert.That(wp.TickSpacing, Is.EqualTo(TickSpacing.Standard));
+            Assert.That(wp.TickSpacing, Is.EqualTo(TickSpacing.HundredTwentyEight));
             Assert.That(wp.Address, Is.EqualTo(address));
         }
 
@@ -168,14 +172,14 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             var (address, wp) = await dex.FindWhirlpool(
                 _tokenPairs[0].Item2,
                 _tokenPairs[0].Item1,
-                TickSpacing.Stable,
+                TickSpacing.Eight,
                 _whirlpoolConfigAddress,
                 TestConfiguration.DefaultCommitment
             );
             Assert.IsNotNull(wp);
             Assert.That(wp.TokenMintA, Is.EqualTo(_tokenPairs[0].Item1));
             Assert.That(wp.TokenMintB, Is.EqualTo(_tokenPairs[0].Item2));
-            Assert.That(wp.TickSpacing, Is.EqualTo(TickSpacing.Standard));
+            Assert.That(wp.TickSpacing, Is.EqualTo(TickSpacing.HundredTwentyEight));
             Assert.That(wp.Address, Is.EqualTo(address));
         }
 
@@ -190,7 +194,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             var (address, wp) = await dex.FindWhirlpool(
                 fakeToken,
                 _tokenPairs[0].Item2,
-                TickSpacing.Standard,
+                TickSpacing.HundredTwentyEight,
                 _whirlpoolConfigAddress,
                 TestConfiguration.DefaultCommitment
             );
@@ -199,7 +203,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             (address, wp) = await dex.FindWhirlpool(
                 _tokenPairs[0].Item1,
                 fakeToken,
-                TickSpacing.Standard,
+                TickSpacing.HundredTwentyEight,
                 _whirlpoolConfigAddress,
                 TestConfiguration.DefaultCommitment
             );

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/IncreaseLiquidityTxApiTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/IncreaseLiquidityTxApiTests.cs
@@ -32,7 +32,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             _defaultCommitment = _context.WhirlpoolClient.DefaultCommitment;
         }
 
-        private static async Task<WhirlpoolsTestFixture> InitializeTestPool()
+        private static async Task<WhirlpoolsTestFixture> InitializeTestPool(bool tokenAIsNative = false)
         {
             WhirlpoolsTestFixture fixture = await WhirlpoolsTestFixture.CreateInstance(
                 _context,
@@ -42,7 +42,8 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
                     {
                         TickLowerIndex = LowerTickIndex, TickUpperIndex = UpperTickIndex, LiquidityAmount = 0
                     }
-                }
+                },
+                tokenAIsNative: tokenAIsNative
             );
             
             return fixture;

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/IncreaseLiquidityTxApiTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/IncreaseLiquidityTxApiTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using Orca;
+using Solana.Unity.Dex.Math;
 using System.Numerics;
 using System.Threading.Tasks;
 using Solana.Unity.Rpc.Models;
@@ -8,6 +9,7 @@ using Solana.Unity.Dex.Orca.Swap;
 using Solana.Unity.Dex.Orca.Core.Accounts;
 using Solana.Unity.Dex.Test.Orca.Params;
 using Solana.Unity.Dex.Orca.Address;
+using Solana.Unity.Dex.Quotes;
 using Solana.Unity.Dex.Test.Orca.Utils;
 using Solana.Unity.Rpc.Types;
 
@@ -16,10 +18,10 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
     [TestFixture]
     public class IncreaseLiquidityTxApiTests
     {
-        private static readonly int lowerTickIndex = 7168;
-        private static readonly int upperTickIndex = 8960;
-        private static readonly int currentTick = 500;
-        
+        private const int LowerTickIndex = 7168;
+        private const int UpperTickIndex = 8960;
+        private const int CurrentTick = 500;
+
         private static TestWhirlpoolContext _context;
         private static Commitment _defaultCommitment;
 
@@ -32,17 +34,13 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
 
         private static async Task<WhirlpoolsTestFixture> InitializeTestPool()
         {
-            int currentTick = 500;
-            int lowerTickIndex = 7168;
-            int upperTickIndex = 8960;
-
             WhirlpoolsTestFixture fixture = await WhirlpoolsTestFixture.CreateInstance(
                 _context,
-                initialSqrtPrice: PriceMath.TickIndexToSqrtPriceX64(currentTick),
+                initialSqrtPrice: PriceMath.TickIndexToSqrtPriceX64(CurrentTick),
                 positions: new FundedPositionParams[]{
                     new()
                     {
-                        TickLowerIndex = lowerTickIndex, TickUpperIndex = upperTickIndex, LiquidityAmount = 0
+                        TickLowerIndex = LowerTickIndex, TickUpperIndex = UpperTickIndex, LiquidityAmount = 0
                     }
                 }
             );
@@ -70,9 +68,9 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             //get liquidity amounts 
             TokenAmounts tokenAmounts = TokenAmounts.FromValues(1_000_000, 0);
             BigInteger liquidityAmount = PoolUtils.EstimateLiquidityFromTokenAmounts(
-                currentTick,
-                lowerTickIndex,
-                upperTickIndex,
+                CurrentTick,
+                LowerTickIndex,
+                UpperTickIndex,
                 tokenAmounts
             );
             
@@ -112,6 +110,89 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
 
             Assert.That(tokenBalanceA, Is.EqualTo(tokenAmounts.TokenA.ToString()));
             Assert.That(tokenBalanceB, Is.EqualTo(tokenAmounts.TokenB.ToString()));
+
+            //position 
+            Position positionAfter = (await _context.WhirlpoolClient.GetPositionAsync(
+                position.PublicKey,
+                _defaultCommitment
+            )).ParsedResult;
+
+            Assert.NotNull(position);
+            Assert.That(positionAfter.Liquidity, Is.EqualTo(liquidityAmount));
+
+            Assert.That(poolAfter.RewardLastUpdatedTimestamp, Is.GreaterThan(poolBefore.RewardLastUpdatedTimestamp));
+            Assert.That(poolAfter.Liquidity, Is.EqualTo(BigInteger.Zero));
+        }
+        
+        [Test]
+        [Description("all things for increasing liquidity of a position in one transaction")]
+        public static async Task IncreaseLiquidityWithQuoteSingleTransaction()
+        {
+            //initialize everything 
+            var testFixture = await InitializeTestPool();
+            IDex dex = new OrcaDex(_context);
+
+            var testInfo = testFixture.GetTestInfo();
+            FundedPositionInfo position = testInfo.Positions[0];
+            Pda whirlpoolPda = testInfo.InitPoolParams.WhirlpoolPda;
+            
+            //get pool snapshot before liquidity increase
+            Whirlpool poolBefore = (await _context.WhirlpoolClient.GetWhirlpoolAsync(
+                testInfo.InitPoolParams.WhirlpoolPda.PublicKey.ToString()
+            )).ParsedResult;
+
+            //get liquidity amounts 
+            TokenAmounts tokenAmounts = TokenAmounts.FromValues(1_000_000, 0);
+            BigInteger liquidityAmount = PoolUtils.EstimateLiquidityFromTokenAmounts(
+                CurrentTick,
+                LowerTickIndex,
+                UpperTickIndex,
+                tokenAmounts
+            );
+
+            IncreaseLiquidityQuote increaseLiquidityQuote = await dex.GetIncreaseLiquidityQuote(
+                testInfo.InitPoolParams.WhirlpoolPda,
+                poolBefore.TokenMintA,
+                tokenAmounts.TokenA,
+                0.01,
+                LowerTickIndex,
+                UpperTickIndex);
+            
+            //create increase liquidity tx
+            Transaction tx = await dex.IncreaseLiquidityWithQuote(
+                position.PublicKey,
+                increaseLiquidityQuote,
+                commitment: TestConfiguration.DefaultCommitment
+            );
+
+            //sign and execute the transaction 
+            tx.Sign(_context.WalletAccount);
+            var increaseResult = await _context.RpcClient.SendTransactionAsync(
+                tx.Serialize(),
+                commitment: TestConfiguration.DefaultCommitment
+            );
+            
+            Assert.IsTrue(increaseResult.WasSuccessful);
+            Assert.IsTrue(await _context.RpcClient.ConfirmTransaction(increaseResult.Result, _defaultCommitment));
+
+            
+            Whirlpool poolAfter = (
+                await _context.WhirlpoolClient.GetWhirlpoolAsync(whirlpoolPda.PublicKey, TestConfiguration.DefaultCommitment)
+            ).ParsedResult;
+            
+            //token balances 
+            string tokenBalanceA = (await _context.RpcClient.GetTokenAccountBalanceAsync(
+                poolAfter.TokenVaultA,
+                _defaultCommitment
+            )).Result.Value.Amount;
+
+            string tokenBalanceB = (await _context.RpcClient.GetTokenAccountBalanceAsync(
+                poolAfter.TokenVaultB,
+                _defaultCommitment
+            )).Result.Value.Amount;
+
+            Assert.That(ulong.Parse(tokenBalanceA), Is.EqualTo((ulong)increaseLiquidityQuote.TokenEstA));
+            Assert.That(ulong.Parse(tokenBalanceB), Is.EqualTo((ulong)increaseLiquidityQuote.TokenEstB));
 
             //position 
             Position positionAfter = (await _context.WhirlpoolClient.GetPositionAsync(

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/OpenPositionTxApiTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/OpenPositionTxApiTests.cs
@@ -15,6 +15,7 @@ using Solana.Unity.Dex.Orca.Swap;
 using Solana.Unity.Dex.Orca.Ticks;
 using Solana.Unity.Dex.Orca.Math;
 using Solana.Unity.Dex.Orca.Address;
+using Solana.Unity.Dex.Quotes;
 using Solana.Unity.Dex.Test.Orca.Utils;
 using Solana.Unity.Dex.Ticks;
 
@@ -23,13 +24,20 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
     [TestFixture]
     public class OpenPositionTxApiTests
     {
+        public static Account WalletAccount;
+        
         private static TestWhirlpoolContext _context;
         private static Commitment _defaultCommitment;
+        
+        private static int _lowerTickIndex = 7168;
+        private static int _upperTickIndex = 8960;
+        private static int _currentTick = 500;
 
         [SetUp]
         public static void Setup()
         {
             _context = ContextFactory.CreateTestWhirlpoolContext(TestConfiguration.SolanaEnvironment);
+            WalletAccount =  _context.WalletAccount;
             _defaultCommitment = _context.WhirlpoolClient.DefaultCommitment;
         }
 
@@ -73,21 +81,20 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
         public static async Task OpenPositionSingleTransaction()
         {
             //create new account to be position opener, and a new context 
-            Account walletAccount = new Account();
 
             //initialize everything 
             PublicKey whirlpoolAddr = await InitializeTestPool();
-            IWhirlpoolContext newContext = await InitializeContext(walletAccount);
-            IDex dex = new OrcaDex(walletAccount, newContext.RpcClient);
+            IWhirlpoolContext newContext = await InitializeContext(WalletAccount);
+            IDex dex = new OrcaDex(WalletAccount, newContext.RpcClient);
             
             int tickLowerIndex = 0;
             int tickUpperIndex = 128;
             
             //position mint account 
-            Account positionMintAccount = new Account();
+            Account positionMintAccount = new();
             Pda positionPda = PdaUtils.GetPosition(_context.ProgramId, positionMintAccount.PublicKey);
 
-            //get the transaction toopen the position 
+            //get the transaction to open the position 
             Transaction tx = await dex.OpenPosition(
                 whirlpoolAddr,
                 positionMintAccount,
@@ -97,7 +104,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             );
             
             //sign and execute the transaction 
-            tx.Sign(walletAccount);
+            tx.Sign(WalletAccount);
             tx.Sign(positionMintAccount);
             var openResult = await newContext.RpcClient.SendTransactionAsync(
                 tx.Serialize(),
@@ -133,8 +140,6 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
         [Description("open a position and increase its liquidity in one transaction")]
         public static async Task OpenPositionIncreaseLiquiditySingleTransaction()
         {
-            int lowerTickIndex = 7168;
-            int upperTickIndex = 8960;
             WhirlpoolsTestFixture fixture = await InitializeTestFixture(); 
 
             var testInfo = fixture.GetTestInfo();
@@ -147,15 +152,23 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             
             IDex dex = new OrcaDex(_context.WalletAccount, _context.RpcClient);
             Account positionMintAccount = new(); 
+            
+            TokenAmounts tokenAmounts = TokenAmounts.FromValues(1_000_000, 0);
+            BigInteger liquidityAmount = PoolUtils.EstimateLiquidityFromTokenAmounts(
+                _currentTick,
+                _lowerTickIndex,
+                _upperTickIndex,
+                tokenAmounts
+            );
 
             //get the transaction to open the position 
             Transaction tx = await dex.OpenPositionWithLiquidity(
                 whirlpoolPda,
                 positionMintAccount,
-                lowerTickIndex,
-                upperTickIndex,
-                1_000_000,
-                0,
+                _lowerTickIndex,
+                _upperTickIndex,
+                tokenAmounts.TokenA,
+                tokenAmounts.TokenB,
                 commitment: TestConfiguration.DefaultCommitment
             );
 
@@ -169,6 +182,87 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
 
             Assert.IsTrue(openResult.WasSuccessful);
             Assert.IsTrue(await _context.RpcClient.ConfirmTransaction(openResult.Result, _defaultCommitment));
+            
+            //retrieve the position
+            PublicKey positionPda = PdaUtils.GetPosition(_context.ProgramId, positionMintAccount);
+
+            Position positionAfter = (await _context.WhirlpoolClient.GetPositionAsync(
+                positionPda,
+                _defaultCommitment
+            )).ParsedResult;
+            
+            Assert.NotNull(positionAfter);
+            Assert.That(positionAfter.Liquidity, Is.EqualTo(liquidityAmount));
+        }
+        
+        [Test]
+        [Description("open a position and increase its liquidity with quote in one transaction")]
+        public static async Task OpenPositionIncreaseLiquidityWithQuoteSingleTransaction()
+        {
+            int lowerTickIndex = 7168;
+            int upperTickIndex = 8960;
+            int currentTick = 500;
+            WhirlpoolsTestFixture fixture = await InitializeTestFixture(); 
+
+            var testInfo = fixture.GetTestInfo();
+            Pda whirlpoolPda = testInfo.InitPoolParams.WhirlpoolPda;
+
+            //get whirlpool 
+            Whirlpool poolBefore = (await _context.WhirlpoolClient.GetWhirlpoolAsync(
+                whirlpoolPda.PublicKey.ToString()
+            )).ParsedResult;
+            
+            IDex dex = new OrcaDex(_context.WalletAccount, _context.RpcClient);
+            Account positionMintAccount = new(); 
+            
+            TokenAmounts tokenAmounts = TokenAmounts.FromValues(1_000_000, 0);
+            BigInteger liquidityAmount = PoolUtils.EstimateLiquidityFromTokenAmounts(
+                currentTick,
+                lowerTickIndex,
+                upperTickIndex,
+                tokenAmounts
+            );
+
+            IncreaseLiquidityQuote increaseLiquidityQuote = await dex.GetIncreaseLiquidityQuote(
+                whirlpoolPda,
+                poolBefore.TokenMintA,
+                tokenAmounts.TokenA,
+                0.01,
+                _lowerTickIndex,
+                _upperTickIndex,
+                commitment: TestConfiguration.DefaultCommitment);
+
+            //get the transaction to open the position 
+            Transaction tx = await dex.OpenPositionWithLiquidityWithQuote(
+                whirlpoolPda,
+                positionMintAccount,
+                lowerTickIndex,
+                upperTickIndex,
+                increaseLiquidityQuote,
+                commitment: TestConfiguration.DefaultCommitment
+            );
+
+            //sign and execute the transaction 
+            tx.Sign(_context.WalletAccount);
+            tx.Sign(positionMintAccount);
+            var openResult = await _context.RpcClient.SendTransactionAsync(
+                tx.Serialize(),
+                commitment: TestConfiguration.DefaultCommitment
+            );
+
+            Assert.IsTrue(openResult.WasSuccessful);
+            Assert.IsTrue(await _context.RpcClient.ConfirmTransaction(openResult.Result, _defaultCommitment));
+            
+            //retrieve the position
+            PublicKey positionPda = PdaUtils.GetPosition(_context.ProgramId, positionMintAccount);
+
+            Position positionAfter = (await _context.WhirlpoolClient.GetPositionAsync(
+                positionPda,
+                _defaultCommitment
+            )).ParsedResult;
+            
+            Assert.NotNull(positionAfter);
+            Assert.That(positionAfter.Liquidity, Is.EqualTo(liquidityAmount));
         }
     }
 }

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/OpenPositionTxApiTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/OpenPositionTxApiTests.cs
@@ -52,7 +52,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
         private static async Task<WhirlpoolsTestFixture> InitializeTestFixture()
         {
             int currentTick = 500;
-            ushort tickSpacing = TickSpacing.Standard;
+            ushort tickSpacing = TickSpacing.HundredTwentyEight;
 
             WhirlpoolsTestFixture fixture = await WhirlpoolsTestFixture.CreateInstance(
                 _context,

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/OpenPositionWithLiquiditySequentiallyTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/OpenPositionWithLiquiditySequentiallyTests.cs
@@ -32,7 +32,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             _defaultCommitment = _context.WhirlpoolClient.DefaultCommitment;
         }
 
-        private static async Task<WhirlpoolsTestFixture> InitializeTestPool()
+        private static async Task<WhirlpoolsTestFixture> InitializeTestPool(bool tokenAIsNative = false)
         {
             WhirlpoolsTestFixture fixture = await WhirlpoolsTestFixture.CreateInstance(
                 _context,
@@ -42,7 +42,8 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
                     {
                         TickLowerIndex = LowerTickIndex, TickUpperIndex = UpperTickIndex, LiquidityAmount = 0
                     }
-                }
+                },
+                tokenAIsNative: tokenAIsNative
             );
             
             return fixture;
@@ -107,6 +108,106 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             tx.Sign(_context.WalletAccount);
             var increaseResult = await _context.RpcClient.SendTransactionAsync(
                 tx.Serialize(),
+                commitment: TestConfiguration.DefaultCommitment
+            );
+            
+            Assert.IsTrue(increaseResult.WasSuccessful);
+            Assert.IsTrue(await _context.RpcClient.ConfirmTransaction(increaseResult.Result, _defaultCommitment));
+
+            
+            Whirlpool poolAfter = (
+                await _context.WhirlpoolClient.GetWhirlpoolAsync(whirlpoolPda.PublicKey, TestConfiguration.DefaultCommitment)
+            ).ParsedResult;
+            
+            //token balances 
+            string tokenBalanceA = (await _context.RpcClient.GetTokenAccountBalanceAsync(
+                poolAfter.TokenVaultA,
+                _defaultCommitment
+            )).Result.Value.Amount;
+
+            string tokenBalanceB = (await _context.RpcClient.GetTokenAccountBalanceAsync(
+                poolAfter.TokenVaultB,
+                _defaultCommitment
+            )).Result.Value.Amount;
+
+            Assert.That(tokenBalanceA, Is.EqualTo(tokenAmounts.TokenA.ToString()));
+            Assert.That(tokenBalanceB, Is.EqualTo(tokenAmounts.TokenB.ToString()));
+
+            //position 
+            Position positionAfter = (await _context.WhirlpoolClient.GetPositionAsync(
+                positionPda,
+                _defaultCommitment
+            )).ParsedResult;
+
+            Assert.NotNull(positionAfter);
+            Assert.That(positionAfter.Liquidity, Is.EqualTo(liquidityAmount));
+
+            Assert.That(poolAfter.RewardLastUpdatedTimestamp, Is.GreaterThan(poolBefore.RewardLastUpdatedTimestamp));
+            Assert.That(poolAfter.Liquidity, Is.EqualTo(BigInteger.Zero));
+        }
+        
+        [Test]
+        [Description("all things for opening a position and increasing liquidity, with closed wsol ata")]
+        public static async Task OpenPositionWithLiquidityClosingAtas()
+        {
+            //initialize everything 
+            var testFixture = await InitializeTestPool(tokenAIsNative: true);
+            var testInfo = testFixture.GetTestInfo();
+            Pda whirlpoolPda = testInfo.InitPoolParams.WhirlpoolPda;
+            
+            IDex dex = new OrcaDex(_context);
+            
+            Account positionMint = new();
+            PublicKey positionPda = PdaUtils.GetPosition(_context.ProgramId, positionMint);
+
+            var openPositionTx = await dex.OpenPosition(
+                testInfo.InitPoolParams.WhirlpoolPda,
+                positionMint, 
+                LowerTickIndex,
+                UpperTickIndex,
+                commitment: _defaultCommitment);
+            
+            openPositionTx.Sign(_context.WalletAccount);
+            openPositionTx.Sign(positionMint);
+            
+            var openResult = await _context.RpcClient.SendTransactionAsync(
+                openPositionTx.Serialize(),
+                commitment: TestConfiguration.DefaultCommitment
+            );
+
+            Assert.IsTrue(openResult.WasSuccessful);
+            Assert.IsTrue(await _context.RpcClient.ConfirmTransaction(openResult.Result, _defaultCommitment));
+            
+            // Close WSOl ata
+            await TokenUtils.CloseAta(_context.RpcClient, AddressConstants.NATIVE_MINT_PUBKEY, _context.WalletAccount, _context.WalletAccount);
+
+            //get pool snapshot before liquidity increase
+            Whirlpool poolBefore = (await _context.WhirlpoolClient.GetWhirlpoolAsync(
+                testInfo.InitPoolParams.WhirlpoolPda.PublicKey.ToString()
+            )).ParsedResult;
+
+            //get liquidity amounts 
+            TokenAmounts tokenAmounts = TokenAmounts.FromValues(1_000_000, 0);
+            BigInteger liquidityAmount = PoolUtils.EstimateLiquidityFromTokenAmounts(
+                CurrentTick,
+                LowerTickIndex,
+                UpperTickIndex,
+                tokenAmounts
+            );
+            
+            //create increase liquidity tx
+            Transaction tx = await dex.IncreaseLiquidity(
+                positionPda,
+                tokenAmounts.TokenA,
+                tokenAmounts.TokenB,
+                commitment: TestConfiguration.DefaultCommitment
+            );
+
+            //sign and execute the transaction 
+            tx.Sign(_context.WalletAccount);
+            var increaseResult = await _context.RpcClient.SendTransactionAsync(
+                tx.Serialize(),
+                skipPreflight: true,
                 commitment: TestConfiguration.DefaultCommitment
             );
             

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/OpenPositionWithLiquiditySequentiallyTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/OpenPositionWithLiquiditySequentiallyTests.cs
@@ -1,0 +1,148 @@
+using NUnit.Framework;
+using Orca;
+using System.Numerics;
+using System.Threading.Tasks;
+
+using Solana.Unity.Wallet;
+using Solana.Unity.Rpc.Models;
+using Solana.Unity.Dex.Orca.Core.Accounts;
+using Solana.Unity.Dex.Orca.Address;
+using Solana.Unity.Dex.Orca.Math;
+using Solana.Unity.Dex.Orca.Swap;
+using Solana.Unity.Dex.Test.Orca.Params;
+using Solana.Unity.Dex.Test.Orca.Utils;
+using Solana.Unity.Rpc.Types;
+
+namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
+{
+    [TestFixture]
+    public class OpenPositionWithMetadataTxApiTests
+    {
+        private const int LowerTickIndex = 7168;
+        private const int UpperTickIndex = 8960;
+        private const int CurrentTick = 500;
+
+        private static TestWhirlpoolContext _context;
+        private static Commitment _defaultCommitment;
+
+        [SetUp]
+        public static void Setup()
+        {
+            _context = ContextFactory.CreateTestWhirlpoolContext(TestConfiguration.SolanaEnvironment);
+            _defaultCommitment = _context.WhirlpoolClient.DefaultCommitment;
+        }
+
+        private static async Task<WhirlpoolsTestFixture> InitializeTestPool()
+        {
+            WhirlpoolsTestFixture fixture = await WhirlpoolsTestFixture.CreateInstance(
+                _context,
+                initialSqrtPrice: PriceMath.TickIndexToSqrtPriceX64(CurrentTick),
+                positions: new FundedPositionParams[]{
+                    new()
+                    {
+                        TickLowerIndex = LowerTickIndex, TickUpperIndex = UpperTickIndex, LiquidityAmount = 0
+                    }
+                }
+            );
+            
+            return fixture;
+        }
+
+        [Test]
+        [Description("all things for opening a position and increasing liquidity in one transaction")]
+        public static async Task OpenPositionWithLiquiditySingleTransaction()
+        {
+            //initialize everything 
+            var testFixture = await InitializeTestPool();
+            var testInfo = testFixture.GetTestInfo();
+            Pda whirlpoolPda = testInfo.InitPoolParams.WhirlpoolPda;
+            
+            IDex dex = new OrcaDex(_context);
+            
+            Account positionMint = new();
+            PublicKey positionPda = PdaUtils.GetPosition(_context.ProgramId, positionMint);
+
+            var openPositionTx = await dex.OpenPosition(
+                testInfo.InitPoolParams.WhirlpoolPda,
+                positionMint, 
+                LowerTickIndex,
+                UpperTickIndex,
+                commitment: _defaultCommitment);
+            
+            openPositionTx.Sign(_context.WalletAccount);
+            openPositionTx.Sign(positionMint);
+            
+            var openResult = await _context.RpcClient.SendTransactionAsync(
+                openPositionTx.Serialize(),
+                commitment: TestConfiguration.DefaultCommitment
+            );
+
+            Assert.IsTrue(openResult.WasSuccessful);
+            Assert.IsTrue(await _context.RpcClient.ConfirmTransaction(openResult.Result, _defaultCommitment));
+
+            
+            //get pool snapshot before liquidity increase
+            Whirlpool poolBefore = (await _context.WhirlpoolClient.GetWhirlpoolAsync(
+                testInfo.InitPoolParams.WhirlpoolPda.PublicKey.ToString()
+            )).ParsedResult;
+
+            //get liquidity amounts 
+            TokenAmounts tokenAmounts = TokenAmounts.FromValues(1_000_000, 0);
+            BigInteger liquidityAmount = PoolUtils.EstimateLiquidityFromTokenAmounts(
+                CurrentTick,
+                LowerTickIndex,
+                UpperTickIndex,
+                tokenAmounts
+            );
+            
+            //create increase liquidity tx
+            Transaction tx = await dex.IncreaseLiquidity(
+                positionPda,
+                tokenAmounts.TokenA,
+                tokenAmounts.TokenB,
+                commitment: TestConfiguration.DefaultCommitment
+            );
+
+            //sign and execute the transaction 
+            tx.Sign(_context.WalletAccount);
+            var increaseResult = await _context.RpcClient.SendTransactionAsync(
+                tx.Serialize(),
+                commitment: TestConfiguration.DefaultCommitment
+            );
+            
+            Assert.IsTrue(increaseResult.WasSuccessful);
+            Assert.IsTrue(await _context.RpcClient.ConfirmTransaction(increaseResult.Result, _defaultCommitment));
+
+            
+            Whirlpool poolAfter = (
+                await _context.WhirlpoolClient.GetWhirlpoolAsync(whirlpoolPda.PublicKey, TestConfiguration.DefaultCommitment)
+            ).ParsedResult;
+            
+            //token balances 
+            string tokenBalanceA = (await _context.RpcClient.GetTokenAccountBalanceAsync(
+                poolAfter.TokenVaultA,
+                _defaultCommitment
+            )).Result.Value.Amount;
+
+            string tokenBalanceB = (await _context.RpcClient.GetTokenAccountBalanceAsync(
+                poolAfter.TokenVaultB,
+                _defaultCommitment
+            )).Result.Value.Amount;
+
+            Assert.That(tokenBalanceA, Is.EqualTo(tokenAmounts.TokenA.ToString()));
+            Assert.That(tokenBalanceB, Is.EqualTo(tokenAmounts.TokenB.ToString()));
+
+            //position 
+            Position positionAfter = (await _context.WhirlpoolClient.GetPositionAsync(
+                positionPda,
+                _defaultCommitment
+            )).ParsedResult;
+
+            Assert.NotNull(positionAfter);
+            Assert.That(positionAfter.Liquidity, Is.EqualTo(liquidityAmount));
+
+            Assert.That(poolAfter.RewardLastUpdatedTimestamp, Is.GreaterThan(poolBefore.RewardLastUpdatedTimestamp));
+            Assert.That(poolAfter.Liquidity, Is.EqualTo(BigInteger.Zero));
+        }
+    }
+}

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/OpenPositionWithMetadataTxApiTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/OpenPositionWithMetadataTxApiTests.cs
@@ -15,7 +15,7 @@ using Solana.Unity.Rpc.Types;
 namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
 {
     [TestFixture]
-    public class OpenPositionWithMetadataTxApiTests
+    public class OpenPositionWithLiquidityTxApiTests
     {
         private static TestWhirlpoolContext _context;
         private static Commitment _defaultCommitment;

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/TokensUtilsTest.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/TokensUtilsTest.cs
@@ -39,6 +39,19 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
         }
         
         [Test]
+        public static async Task GetTokenByMint()
+        {
+            string orcaMint = "orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE";
+            IDex dex = new OrcaDex(new Account(), _context.RpcClient);
+            TokenData token = await dex.GetTokenByMint(orcaMint); 
+            
+            Assert.IsNotNull(token);
+            Assert.IsTrue(token.Mint.Equals(orcaMint));
+            Assert.IsTrue(token.Symbol.Equals("ORCA"));
+        }
+
+        
+        [Test]
         public static async Task GetTokensWithInterface()
         {
             IDex dex = new OrcaDex(new Account(), _context.RpcClient);
@@ -56,6 +69,51 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             
             Assert.IsNotNull(token);
             Assert.IsNotNull(token.Mint);
+        }
+        
+        [Test]
+        public static async Task GetPositions()
+        {
+            // Open a position to ensure we have one
+            OpenPositionTxApiTests.Setup();
+            await OpenPositionTxApiTests.OpenPositionSingleTransaction();
+            
+            // Get positions
+            IDex dex = new OrcaDex(_context.WalletPubKey, _context.RpcClient);
+            IList<PublicKey> positions = await dex.GetPositions(commitment: TestConfiguration.DefaultCommitment);
+            
+            Assert.IsNotNull(positions);
+            Assert.IsTrue(positions.Count > 0);
+        }
+        
+        [Test]
+        public static async Task GetEmptyPositionsForOwner()
+        {
+            Account newAccount = new();
+            
+            // Get positions
+            IDex dex = new OrcaDex(_context.WalletPubKey, _context.RpcClient);
+            IList<PublicKey> positions = await dex.GetPositions(owner: newAccount, commitment: TestConfiguration.DefaultCommitment);
+            
+            Assert.IsNotNull(positions);
+            Assert.IsTrue(positions.Count == 0);
+        }
+        
+        [Test]
+        public static async Task GetPositionsForOwner()
+        {
+            // Open a position on a new account
+            OpenPositionTxApiTests.Setup();
+            Account newAccount = new();
+            OpenPositionTxApiTests.WalletAccount = newAccount;
+            await OpenPositionTxApiTests.OpenPositionSingleTransaction();
+            
+            // Get positions
+            IDex dex = new OrcaDex(_context.WalletPubKey, _context.RpcClient);
+            IList<PublicKey> positions = await dex.GetPositions(owner: newAccount, commitment: TestConfiguration.DefaultCommitment);
+            
+            Assert.IsNotNull(positions);
+            Assert.IsTrue(positions.Count == 1);
         }
     }
 }

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/UpdateFeesAndRewardsTxApiTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/TxApi/UpdateFeesAndRewardsTxApiTests.cs
@@ -107,8 +107,6 @@ namespace Solana.Unity.Dex.Test.Orca.Integration.TxApi
             //generate the transaction to update fees and rewards 
             Transaction tx = await dex.UpdateFeesAndRewards(
                 position.PublicKey,
-                tickArrayPda.PublicKey,
-                tickArrayPda.PublicKey,
                 commitment: TestConfiguration.DefaultCommitment
             );
 

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/UpdateFeesRewardsTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/UpdateFeesRewardsTests.cs
@@ -171,7 +171,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             int tickLowerIndex = 29440;
             int tickUpperIndex = 33536;
 
-            ushort tickSpacing = TickSpacing.Standard;
+            ushort tickSpacing = TickSpacing.HundredTwentyEight;
             
             PoolInitResult poolInitResult = await PoolTestUtils.BuildPool(
                 _context, 

--- a/test/Solana.Unity.Dex.Test/Orca/SdkTests/UtilsTests/DecimalsUtilsTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/SdkTests/UtilsTests/DecimalsUtilsTests.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+using Solana.Unity.Dex.Math;
+
+namespace Solana.Unity.Dex.Test.Orca.SdkTests.UtilsTests
+{
+    public static class TestDecimalsUtils
+    {
+        [TestFixture]
+        public static class TestDecimalUtils
+        {
+            [Test]
+            [Description("Convert to and from")]
+            public static void ConvertToAndFrom() 
+            {
+                ulong value = 100_000_000;
+                int decimals = 6;
+                var valueDouble = DecimalUtil.FromUlong(value, decimals);
+                Assert.IsTrue(valueDouble.Equals(100.0));
+                
+                Assert.IsTrue(DecimalUtil.ToUlong(valueDouble, decimals).Equals(value));
+                Assert.IsTrue(DecimalUtil.ToUlong((float)valueDouble, decimals).Equals(value));
+
+                Assert.IsTrue(DecimalUtil.FromBigInteger(value, decimals).Equals(valueDouble));
+            }
+            
+        }
+    }
+}

--- a/test/Solana.Unity.Dex.Test/Orca/SdkTests/UtilsTests/PoolUtilsTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/SdkTests/UtilsTests/PoolUtilsTests.cs
@@ -11,7 +11,7 @@ using Solana.Unity.Dex.Test.Orca.Utils;
 using Solana.Unity.Dex.Orca.Core.Accounts;
 using Solana.Unity.Dex.Swap;
 
-namespace Solana.Unity.Dex.Test.Orca.Sdk.Utils
+namespace Solana.Unity.Dex.Test.Orca.SdkTests.UtilsTests
 {
     //ALL 6 PASSING 
     public static class PoolUtilsTests

--- a/test/Solana.Unity.Dex.Test/Orca/SdkTests/UtilsTests/SwapUtilsTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/SdkTests/UtilsTests/SwapUtilsTests.cs
@@ -1,16 +1,25 @@
 using NUnit.Framework;
-
+using Solana.Unity.Dex.Orca.Address;
 using Solana.Unity.Dex.Orca.Swap;
 using Solana.Unity.Dex.Test.Orca.Utils;
 using Solana.Unity.Dex.Orca.Core.Accounts;
+using Solana.Unity.Dex.Orca.Ticks;
 using Solana.Unity.Wallet;
+using System.Collections.Generic;
 
 namespace Solana.Unity.Dex.Test.Orca.SdkTests.UtilsTests
 {
     [TestFixture]
     public static class SwapUtilsTests
     {
-        //TODO: (LOW) can these be combined into one test using TestCase attribute 
+        private static TestWhirlpoolContext _context;
+
+        [SetUp]
+        public static void Setup()
+        {
+            _context = ContextFactory.CreateTestWhirlpoolContext(TestConfiguration.SolanaEnvironment);
+        }
+        
         [Test]
         [Description("SwapToken is tokenA and is an input")]
         public static void SwapTokenTokenAInput() 
@@ -70,5 +79,216 @@ namespace Solana.Unity.Dex.Test.Orca.SdkTests.UtilsTests
             
             Assert.That(result, Is.EqualTo(SwapDirection.None));
         }
+        
+        [Test]
+        [Description("getTickArrayPublicKeys, a->b, ts = 64, tickCurrentIndex = 0")]
+        public static void GetTickArrayPublicKeysAToB64Ticks() 
+        {
+            PublicKey programId = _context.ProgramId;
+            PublicKey whirlpoolPubkey = new Account().PublicKey;
+            ushort tickSpacing = 64;
+            int ticksInArray = tickSpacing * TickConstants.TICK_ARRAY_SIZE;
+            bool aToB = true;
+            int tickCurrentIndex = 0;
+
+            IList<PublicKey> result = SwapUtils.GetTickArrayPublicKeys(
+                tickCurrentIndex,
+                tickSpacing,
+                aToB,
+                programId,
+                whirlpoolPubkey
+            );
+            var expected = new List<PublicKey>
+            {
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 0).PublicKey,
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * -1).PublicKey,
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * -2).PublicKey,
+            };
+            for (int i = 0; i < result.Count; i++)
+            {
+                Assert.IsTrue(result[i].Equals(expected[i]));
+            }
+        }
+        
+        [Test]
+        [Description("getTickArrayPublicKeys, a->b, ts = 64, tickCurrentIndex = 64*TICK_ARRAY_SIZE - 64")]
+        public static void GetTickArrayPublicKeysAToB64TicksCurrentIndex() 
+        {
+            PublicKey programId = _context.ProgramId;
+            PublicKey whirlpoolPubkey = new Account().PublicKey;
+            ushort tickSpacing = 64;
+            int ticksInArray = tickSpacing * TickConstants.TICK_ARRAY_SIZE;
+            bool aToB = true;
+            var tickCurrentIndex = tickSpacing * TickConstants.TICK_ARRAY_SIZE - tickSpacing;
+
+            IList<PublicKey> result = SwapUtils.GetTickArrayPublicKeys(
+                tickCurrentIndex,
+                tickSpacing,
+                aToB,
+                programId,
+                whirlpoolPubkey
+            );
+            var expected = new List<PublicKey>
+            {
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 0).PublicKey,
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * -1).PublicKey,
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * -2).PublicKey,
+            };
+            for (int i = 0; i < result.Count; i++)
+            {
+                Assert.IsTrue(result[i].Equals(expected[i]));
+            }
+        }
+        
+        [Test]
+        [Description("getTickArrayPublicKeys, a->b, ts = 64, tickCurrentIndex = 64*TICK_ARRAY_SIZE - 1")]
+        public static void GetTickArrayPublicKeysAToB64TicksCurrentIndexMin1() 
+        {
+            PublicKey programId = _context.ProgramId;
+            PublicKey whirlpoolPubkey = new Account().PublicKey;
+            ushort tickSpacing = 64;
+            int ticksInArray = tickSpacing * TickConstants.TICK_ARRAY_SIZE;
+            bool aToB = true;
+            var tickCurrentIndex = tickSpacing * TickConstants.TICK_ARRAY_SIZE - 1;
+
+            IList<PublicKey> result = SwapUtils.GetTickArrayPublicKeys(
+                tickCurrentIndex,
+                tickSpacing,
+                aToB,
+                programId,
+                whirlpoolPubkey
+            );
+            var expected = new List<PublicKey>
+            {
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 0).PublicKey,
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * -1).PublicKey,
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * -2).PublicKey,
+            };
+            for (int i = 0; i < result.Count; i++)
+            {
+                Assert.IsTrue(result[i].Equals(expected[i]));
+            }
+        }
+        
+        [Test]
+        [Description("getTickArrayPublicKeys, b->a, shifted, ts = 64, tickCurrentIndex = 0")]
+        public static void GetTickArrayPublicKeysBToA64() 
+        {
+            PublicKey programId = _context.ProgramId;
+            PublicKey whirlpoolPubkey = new Account().PublicKey;
+            ushort tickSpacing = 64;
+            int ticksInArray = tickSpacing * TickConstants.TICK_ARRAY_SIZE;
+            bool aToB = false;
+            var tickCurrentIndex = 0;
+
+            IList<PublicKey> result = SwapUtils.GetTickArrayPublicKeys(
+                tickCurrentIndex,
+                tickSpacing,
+                aToB,
+                programId,
+                whirlpoolPubkey
+            );
+            var expected = new List<PublicKey>
+            {
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 0).PublicKey,
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 1).PublicKey,
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 2).PublicKey,
+            };
+            for (int i = 0; i < result.Count; i++)
+            {
+                Assert.IsTrue(result[i].Equals(expected[i]));
+            }
+        }
+        
+        [Test]
+        [Description("getTickArrayPublicKeys, b->a, shifted, ts = 64, tickCurrentIndex = 64*TICK_ARRAY_SIZE - 64 - 1")]
+        public static void GetTickArrayPublicKeysBToA64Min1() 
+        {
+            PublicKey programId = _context.ProgramId;
+            PublicKey whirlpoolPubkey = new Account().PublicKey;
+            ushort tickSpacing = 64;
+            int ticksInArray = tickSpacing * TickConstants.TICK_ARRAY_SIZE;
+            bool aToB = false;
+            var tickCurrentIndex = tickSpacing * TickConstants.TICK_ARRAY_SIZE - tickSpacing - 1;
+
+            IList<PublicKey> result = SwapUtils.GetTickArrayPublicKeys(
+                tickCurrentIndex,
+                tickSpacing,
+                aToB,
+                programId,
+                whirlpoolPubkey
+            );
+            var expected = new List<PublicKey>
+            {
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 0).PublicKey,
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 1).PublicKey,
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 2).PublicKey,
+            };
+            for (int i = 0; i < result.Count; i++)
+            {
+                Assert.IsTrue(result[i].Equals(expected[i]));
+            }
+        }
+        
+        [Test]
+        [Description("getTickArrayPublicKeys, b->a, shifted, ts = 64, tickCurrentIndex = 64*TICK_ARRAY_SIZE - 64")]
+        public static void GetTickArrayPublicKeysBToA64Min64() 
+        {
+            PublicKey programId = _context.ProgramId;
+            PublicKey whirlpoolPubkey = new Account().PublicKey;
+            ushort tickSpacing = 64;
+            int ticksInArray = tickSpacing * TickConstants.TICK_ARRAY_SIZE;
+            bool aToB = false;
+            var tickCurrentIndex = tickSpacing * TickConstants.TICK_ARRAY_SIZE - tickSpacing;
+
+            IList<PublicKey> result = SwapUtils.GetTickArrayPublicKeys(
+                tickCurrentIndex,
+                tickSpacing,
+                aToB,
+                programId,
+                whirlpoolPubkey
+            );
+            var expected = new List<PublicKey>
+            {
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 1).PublicKey,
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 2).PublicKey,
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 3).PublicKey,
+            };
+            for (int i = 0; i < result.Count; i++)
+            {
+                Assert.IsTrue(result[i].Equals(expected[i]));
+            }
+        }
+        
+        [Test]
+        [Description("getTickArrayPublicKeys, b->a, shifted, ts = 64, tickCurrentIndex = 64*TICK_ARRAY_SIZE - 1")]
+        public static void GetTickArrayPublicKeysBToA64Min64S() 
+        {
+            PublicKey programId = _context.ProgramId;
+            PublicKey whirlpoolPubkey = new Account().PublicKey;
+            ushort tickSpacing = 64;
+            int ticksInArray = tickSpacing * TickConstants.TICK_ARRAY_SIZE;
+            bool aToB = false;
+            var tickCurrentIndex = tickSpacing * TickConstants.TICK_ARRAY_SIZE - 1;
+
+            IList<PublicKey> result = SwapUtils.GetTickArrayPublicKeys(
+                tickCurrentIndex,
+                tickSpacing,
+                aToB,
+                programId,
+                whirlpoolPubkey
+            );
+            var expected = new List<PublicKey>
+            {
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 1).PublicKey,
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 2).PublicKey,
+                PdaUtils.GetTickArray(programId, whirlpoolPubkey, ticksInArray * 3).PublicKey,
+            };
+            for (int i = 0; i < result.Count; i++)
+            {
+                Assert.IsTrue(result[i].Equals(expected[i]));
+            }
+        }
+        
     }
 }

--- a/test/Solana.Unity.Dex.Test/Orca/SdkTests/UtilsTests/TickArraySequenceTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/SdkTests/UtilsTests/TickArraySequenceTests.cs
@@ -11,7 +11,7 @@ namespace Solana.Unity.Dex.Test.Orca.SdkTests.UtilsTests
     public static class TickArraySequenceTests
     {
         [TestFixture]
-        public static class CheckArrayContainsTickIndex
+        public static class IsValidTIckArray0
         {
             private static readonly TickArrayContainer _tickArray0 = TestDataUtils.BuildTickArrayData(0, new int[]{0, 32, 63});
             private static readonly TickArrayContainer _tickArray1 = TestDataUtils.BuildTickArrayData(64 * TickConstants.TICK_ARRAY_SIZE * -1, new int[]{0, 50});
@@ -19,31 +19,31 @@ namespace Solana.Unity.Dex.Test.Orca.SdkTests.UtilsTests
             
             //TODO: (LOW) can these be combined into one test using TestCase attribute 
             [Test]
-            [Description("a->b, arrayIndex 0 contains index")]
+            [Description("a->b, |--------ta2--------|--------ta1------i-|--------ta0--------|")]
             public static void AToBCheckArrayContainsIndex() 
             {
                 var seq = new TickArraySequence(
-                    new TickArrayContainer[] { _tickArray0, _tickArray1, _tickArray2 },
+                    new[] { _tickArray0, _tickArray1, _tickArray2 },
                     64,
                     true
                 );
                 
-                Assert.IsTrue(seq.CheckArrayContainsTickIndex(0, 250));
+                Assert.IsFalse(seq.IsValidTickArray0(-1*64));
                 Assert.IsFalse(seq.CheckArrayContainsTickIndex(0, -64));
             }
             
             [Test]
             [Description("b->a, arrayIndex 0 contains index")]
-            public static void BToACheckArrayContainsIndex() //b->a, arrayIndex 0 contains index
+            public static void BToACheckArrayContainsIndex()
             {
                 var seq = new TickArraySequence(
-                    new TickArrayContainer[] { _tickArray2, _tickArray1, _tickArray0 },
+                    new[] { _tickArray2, _tickArray1, _tickArray0 },
                     64,
                     false
                 );
 
                 Assert.IsTrue(seq.CheckArrayContainsTickIndex(0, -10000));
-                Assert.IsFalse(seq.CheckArrayContainsTickIndex(0, -64));
+                Assert.IsFalse(seq.IsValidTickArray0(-1));
             }
             
             [Test]
@@ -51,12 +51,77 @@ namespace Solana.Unity.Dex.Test.Orca.SdkTests.UtilsTests
             public static void NullDoesNotContainIndex() //
             {
                 var seq = new TickArraySequence(
-                    new TickArrayContainer[] { _tickArray2, TestDataUtils.TestEmptyTickArray, _tickArray0 },
+                    new[] { _tickArray2, TestDataUtils.TestEmptyTickArray, _tickArray0 },
                     64,
                     false
                 );
 
                 Assert.IsFalse(seq.CheckArrayContainsTickIndex(1, -64));
+            }
+            
+            [Test]
+            [Description("b->a, ---|i-------ta2--------|--------ta1--------|--------ta0--------|")]
+            public static void BtoATest1() //
+            {
+                var seq = new TickArraySequence(
+                    new[] { _tickArray2, TestDataUtils.TestEmptyTickArray, _tickArray0 },
+                    64,
+                    false
+                );
+                var ta2StartTickIndex = 64 * TickConstants.TICK_ARRAY_SIZE * -2;
+                Assert.IsTrue(seq.IsValidTickArray0(ta2StartTickIndex + 64));
+            }
+            
+            [Test]
+            [Description("b->a, ---|--------ta2-----i--|--------ta1--------|--------ta0--------|")]
+            public static void BtoATest2() //
+            {
+                var seq = new TickArraySequence(
+                    new[] { _tickArray2, TestDataUtils.TestEmptyTickArray, _tickArray0 },
+                    64,
+                    false
+                );
+                var ta2StartTickIndex = 64 * TickConstants.TICK_ARRAY_SIZE * -1;
+                Assert.IsTrue(seq.IsValidTickArray0(ta2StartTickIndex - 64 - 1));
+            }
+            
+            [Test]
+            [Description("b->a, ---|--------ta2------i-|--------ta1--------|--------ta0--------|")]
+            public static void BtoATest3() //
+            {
+                var seq = new TickArraySequence(
+                    new[] { _tickArray2, TestDataUtils.TestEmptyTickArray, _tickArray0 },
+                    64,
+                    false
+                );
+                var ta2StartTickIndex = 64 * TickConstants.TICK_ARRAY_SIZE * -1;
+                Assert.IsFalse(seq.IsValidTickArray0(ta2StartTickIndex - 64));
+            }
+            
+            [Test]
+            [Description("b->a, ---|--------ta2-------i|--------ta1--------|--------ta0--------|")]
+            public static void BtoATest4() //
+            {
+                var seq = new TickArraySequence(
+                    new[] { _tickArray2, TestDataUtils.TestEmptyTickArray, _tickArray0 },
+                    64,
+                    false
+                );
+                var ta2StartTickIndex = 64 * TickConstants.TICK_ARRAY_SIZE * -1;
+                Assert.IsFalse(seq.IsValidTickArray0(ta2StartTickIndex - 1));
+            }
+            
+            [Test]
+            [Description("b->a, ---|--------ta2--------|i-------ta1--------|--------ta0--------|")]
+            public static void BtoATest5() //
+            {
+                var seq = new TickArraySequence(
+                    new[] { _tickArray2, TestDataUtils.TestEmptyTickArray, _tickArray0 },
+                    64,
+                    false
+                );
+                var ta2StartTickIndex = 64 * TickConstants.TICK_ARRAY_SIZE * -1;
+                Assert.IsFalse(seq.IsValidTickArray0(ta2StartTickIndex));
             }
         }
 

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/ConfigTestUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/ConfigTestUtils.cs
@@ -81,9 +81,9 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
                 RewardEmissionsSuperAuthorityKeyPair = new Account()
             };
 
-            Account configKeypair = new Account(); 
+            Account configKeypair = new(); 
             
-            InitializeConfigParams configInitInfo = new InitializeConfigParams
+            InitializeConfigParams configInitInfo = new()
             {
                 Accounts = new InitializeConfigAccounts
                 {

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/FeeTierTestUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/FeeTierTestUtils.cs
@@ -13,7 +13,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
     public static class FeeTierTestUtils
     {
         private const ushort DefaultFeeRate = 3000; 
-        private const ushort DefaultTickSpacing = TickSpacing.Standard;
+        private const ushort DefaultTickSpacing = TickSpacing.HundredTwentyEight;
         
         public static TransactionInstruction InitializeFeeTierInstruction(
             TestWhirlpoolContext ctx,
@@ -67,7 +67,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
 
         public static InitializeFeeTierParams GenerateDefaultParams(
             TestWhirlpoolContext ctx,
-            ushort tickSpacing = TickSpacing.Standard,
+            ushort tickSpacing = TickSpacing.HundredTwentyEight,
             ushort defaultFeeRate = 3000
         )
         {

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/LiquidityTestUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/LiquidityTestUtils.cs
@@ -292,7 +292,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             );
         }
         
-        private static async Task<PublicKey> CreateAssociatedTokenAccountInstructionIfNotExtant(
+        public static async Task<PublicKey> CreateAssociatedTokenAccountInstructionIfNotExtant(
             PublicKey owner,
             PublicKey mintAddress,
             Account feePayer,

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/LiquidityTestUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/LiquidityTestUtils.cs
@@ -304,9 +304,12 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             bool exists = await TokenUtilsTransaction.TokenAccountExists(
                 rpc, ata, commitment
             );
+            var recentHash = await rpc.GetRecentBlockHashAsync(commitment);
             if (!exists)
             {
                 TransactionBuilder builder = new();
+                builder.SetFeePayer(feePayer);
+                builder.SetRecentBlockHash(recentHash.Result.Value.Blockhash);
                 builder.AddInstruction(
                     AssociatedTokenAccountProgram.CreateAssociatedTokenAccount(
                         feePayer, owner, mintAddress

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/LiquidityTestUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/LiquidityTestUtils.cs
@@ -292,13 +292,11 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             );
         }
         
-        public static async Task<PublicKey> CreateAssociatedTokenAccountInstructionIfNotExtant(
-            PublicKey owner,
+        public static async Task CreateAssociatedTokenAccountInstructionIfNotExtant(PublicKey owner,
             PublicKey mintAddress,
             Account feePayer,
             IRpcClient rpc,
-            Commitment commitment
-        )
+            Commitment commitment)
         {
             var ata = AssociatedTokenAccountProgram.DeriveAssociatedTokenAccount(owner, mintAddress);
             bool exists = await TokenUtilsTransaction.TokenAccountExists(
@@ -312,14 +310,13 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
                 builder.SetRecentBlockHash(recentHash.Result.Value.Blockhash);
                 builder.AddInstruction(
                     AssociatedTokenAccountProgram.CreateAssociatedTokenAccount(
-                        feePayer, owner, mintAddress
+                        feePayer, owner, mintAddress, idempotent: true
                     )
                 );
                 var res = await rpc.SendTransactionAsync(builder.Build(feePayer), commitment: commitment);
                 Assert.IsTrue(res.WasSuccessful);
                 Assert.IsTrue(await rpc.ConfirmTransaction(res.Result, commitment: commitment));
             }
-            return ata;
         }
     }
 }

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/PoolTestUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/PoolTestUtils.cs
@@ -274,9 +274,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
 
             var fundedPositions = await PositionTestUtils.FundPositionsAsync(
                 ctx,
-                initPoolParams: initResult.InitPoolParams, 
-                tokenAccountA: initResult.TokenAccountA,
-                tokenAccountB: initResult.TokenAccountB,
+                initPoolParams: initResult.InitPoolParams,
                 fundParams: fundParams
             );
 

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/PoolTestUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/PoolTestUtils.cs
@@ -110,7 +110,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
         public static async Task<PoolInitResult> BuildPool(
             TestWhirlpoolContext ctx,
             InitializeConfigParams initConfigParams = null,
-            ushort tickSpacing = TickSpacing.Standard,
+            ushort tickSpacing = TickSpacing.HundredTwentyEight,
             ushort defaultFeeRate = 3000,
             BigInteger? initSqrtPrice = null,
             bool tokenAIsNative = false, 
@@ -190,7 +190,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
         public static async Task<PoolInitResult> BuildPoolWithTokens(
             TestWhirlpoolContext ctx,
             InitializeConfigParams initConfigParams,
-            ushort tickSpacing = TickSpacing.Standard,
+            ushort tickSpacing = TickSpacing.HundredTwentyEight,
             ushort defaultFeeRate = 3000,
             BigInteger? initSqrtPrice = null,
             BigInteger? mintAmount = null,
@@ -229,7 +229,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             TestWhirlpoolContext ctx,
             InitializeConfigParams initConfigParams = null,
             InitializeFeeTierParams initFeeTierParams = null,
-            ushort tickSpacing = TickSpacing.Standard,
+            ushort tickSpacing = TickSpacing.HundredTwentyEight,
             ushort defaultFeeRate = 3000,
             BigInteger? initSqrtPrice = null,
             BigInteger? mintAmount = null,

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/PositionTestUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/PositionTestUtils.cs
@@ -9,7 +9,6 @@ using Solana.Unity.Dex.Orca.Math;
 using Solana.Unity.Dex.Orca.Swap;
 using Solana.Unity.Dex.Orca.Ticks;
 using Solana.Unity.Dex.Orca.Address;
-using Solana.Unity.Dex.Orca.SolanaApi;
 using Solana.Unity.Dex.Test.Orca.Params;
 using Solana.Unity.Dex.Orca.Core.Program;
 using Solana.Unity.Dex.Orca.Core.Types;
@@ -332,6 +331,8 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
                     tickSpacing: initPoolParams.TickSpacing
                 )
             );
+
+            await Task.Delay(5000);
 
             //if there is liquidity, we must increase liquidity 
             if (fundParam.LiquidityAmount > 0)

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/PositionTestUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/PositionTestUtils.cs
@@ -9,6 +9,7 @@ using Solana.Unity.Dex.Orca.Math;
 using Solana.Unity.Dex.Orca.Swap;
 using Solana.Unity.Dex.Orca.Ticks;
 using Solana.Unity.Dex.Orca.Address;
+using Solana.Unity.Dex.Orca.Core.Accounts;
 using Solana.Unity.Dex.Test.Orca.Params;
 using Solana.Unity.Dex.Orca.Core.Program;
 using Solana.Unity.Dex.Orca.Core.Types;
@@ -332,11 +333,27 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
                 )
             );
 
-            await Task.Delay(5000);
-
             //if there is liquidity, we must increase liquidity 
             if (fundParam.LiquidityAmount > 0)
             {
+                //get whirlpool 
+                Whirlpool whirlpool = (await ctx.WhirlpoolClient.GetWhirlpoolAsync(initPoolParams.WhirlpoolPda.PublicKey, ctx.WhirlpoolClient.DefaultCommitment)).ParsedResult;
+
+                await LiquidityTestUtils.CreateAssociatedTokenAccountInstructionIfNotExtant(
+                    ctx.WalletAccount,
+                    whirlpool.TokenMintA,
+                    feePayer,
+                    ctx.RpcClient,
+                    ctx.WhirlpoolClient.DefaultCommitment);
+                
+                await LiquidityTestUtils.CreateAssociatedTokenAccountInstructionIfNotExtant(
+                    ctx.WalletAccount,
+                    whirlpool.TokenMintB,
+                    feePayer,
+                    ctx.RpcClient,
+                    ctx.WhirlpoolClient.DefaultCommitment);
+                
+                
                 //get token amounts 
                 TokenAmounts tokenAmounts = PoolUtils.GetTokenAmountsFromLiquidity(
                     liquidity: fundParam.LiquidityAmount,

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/TickArrayTestUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/TickArrayTestUtils.cs
@@ -82,7 +82,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             PublicKey whirlpool,
             int startTickIndex, 
             int arrayCount, 
-            ushort tickSpacing = TickSpacing.Standard,
+            ushort tickSpacing = TickSpacing.HundredTwentyEight,
             bool aToB = false,
             Account funder = null
         )

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/WhirlpoolTestFixture.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/WhirlpoolTestFixture.cs
@@ -13,8 +13,6 @@ using Solana.Unity.Dex.Ticks;
 
 namespace Solana.Unity.Dex.Test.Orca.Utils
 {
-    //TODO: (LOW) this class seems badly named. The idea of test fixtures is good, but they 
-    // need to be more organized. And maybe used in more cases 
     public class WhirlpoolsTestFixture
     {
         private TestWhirlpoolContext _context;
@@ -33,7 +31,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             WhirlpoolPda = new Pda(AddressConstants.DEFAULT_PUBLIC_KEY, 0),
             TokenVaultAKeyPair = new Account(),
             TokenVaultBKeyPair = new Account(),
-            TickSpacing = TickSpacing.Standard, //TODO: (LOW) this is used alot, should be a global default somewhere
+            TickSpacing = TickSpacing.HundredTwentyEight,
         };
         private InitializeConfigParams _initConfigParams = new InitializeConfigParams
         {
@@ -62,10 +60,11 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
         
         public static async Task<WhirlpoolsTestFixture> CreateInstance(
             TestWhirlpoolContext ctx,
-            ushort tickSpacing = TickSpacing.Standard, 
+            ushort tickSpacing = TickSpacing.HundredTwentyEight, 
             BigInteger? initialSqrtPrice = null,
             FundedPositionParams[] positions = null, 
-            RewardParams[] rewards = null
+            RewardParams[] rewards = null,
+            bool tokenAIsNative = false
         )
         {
             WhirlpoolsTestFixture output = new(ctx);
@@ -76,7 +75,8 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
                 initConfigParams,
                 tickSpacing,
                 InitializeFeeTierParams.DefaultDefaultFeeRate,
-                initialSqrtPrice
+                initialSqrtPrice,
+                tokenAIsNative: tokenAIsNative
             );
             
             output._initPoolParams = result.InitPoolParams;

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/WhirlpoolTestFixture.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/WhirlpoolTestFixture.cs
@@ -94,8 +94,6 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
                 output._positions = (await PositionTestUtils.FundPositionsAsync(
                     ctx,
                     output._initPoolParams,
-                    output._tokenAccountA,
-                    output._tokenAccountB,
                     positions
                 )).ToArray();
             }


### PR DESCRIPTION
Include changes from https://gist.github.com/yugure-orca/dfc8027455b2db8bdb2bac4cf255acad

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature/Bug | Yes | - |

## Problem

See https://gist.github.com/yugure-orca/dfc8027455b2db8bdb2bac4cf255acad for detailed description

## Discussion

# Solana.Unity.Dex/IDex.cs

## Swap
Isn't amountSpecifiedTokenType almost the same role as inputTokenMintAddress?

The typescript-SDK's amountSpecifiedIsInput is used to switch between **ExactIn** and **ExactOut** modes.

In ExactOut, you can specify that you want to swap to get 500 USDC.

👉This mode is especially important for payments, and should be used more often for in-game currency exchange.

### Solution

- Removed amountSpecifiedTokenType and using amountSpecifiedIsInput to switch between **ExactIn** and **ExactOut** modes.
- Added a test case using ExactOut mode

## OpenPositionWithLiquidity
I seem to recall an error when including an instruction to initialize a TickArray and an instruction to use a TickArray in the same transaction.

I think this is an Anchor issue, but if it happens in testing, the current workaround is to separate the transactions and execute them serially.

### Comments

Doesn't seems to be the case, the two test cases that open and increase liquidity in one transaction are passing.

## OpenPositionWithLiquidity & IncreaseLiquidity
If the methods only receive tokenMaxA and tokenMaxB, the concept of slippage will no longer exist.

It may be necessary to either receive quote or liquidity as well.

### Solution

- Added slippage parameter and changed input parameter to tokenAmountA and TokenAmountB to compute max values from the given slippage
- Added OpenPositionWithLiquidityWithQuote and IncreaseLiquidityWithQuote that accepts quotes obeject as input
- Added tests cases

## UpdateFeesAndRewards & UpdateAnd...
IncreaseLiquidity also use ``tickArrayLower`` and ``tickArrayUpper``, but it do not accept them.

I think it is possible to get from the position.

### Solution

- Removed from the input parameters and retrieved from the position.

## CollectRewards
``rewardMintAddress`` and ``rewardVaultAddress`` should be known from the pool data.

Compared to other methods, this argument seems to show low-level processing.

### Solution

- Simplified and retrieved ``rewardMintAddress`` and ``rewardVaultAddress`` from the pool data

## GetSwapQuote
Comment summary is the same as GetSwapQuoteFromWhirlpool?

Is it a method to find or route a Whirlpool?

### Solution

- Updated the description. The GetSwapQuote allows to directly get a quote given the input/ouput mint

## FindWhirlpoolAddress
There is a restriction on the order of tokenMintA and tokenMintB: SOL/USDC but not USDC/SOL.

We can either ask the user to enter tokenMintA and tokenMintB in this order, or we can find the pair without distinguishing between A and B.
Maybe the later is beginner-friendly.

### Comment

The TryFindWhirlpool internally is already trying to find a pool for the reverse token mints, in case of failure with the given tokens order. 

## GetTokenBySymbol

Symbol is fine, but I think ByMint is safer, since it can be duplicated or changed (e.g. BTC to soBTC).

### Solution

- Added a GetTokenByMint

## missing? : FindPositions
I think that devs need a way to get a list of positions held by users.

https://github.com/everlastingsong/tour-de-whirlpool/blob/main/src_localization/EN/041_get_positions.ts

### Solution

- Implemented and added test cases

## General

### commitment
I think that it is OK to take a default value of commitment from RPCClient.

If the default value is ``Finalized``, many will specify ``Confirmed`` or ``Processed`` on each call.

Because ``Finalized`` takes approx 10-15 sec.

### Solution

- All the methods now use the default commitment from the RPCClient, if no commitment is specified, so that it can be defined globally.

### tickSpacing
https://github.com/garbles-labs/Solana.Unity-Core/blob/master/src/Solana.Unity.Dex/Ticks/TickSpacing.cs

It's hard to name, but a stable pool like USDC/USDT has tickSpacing 1.
I think the most general-purpose and usable tickSpacing is 64 (0.3% fee).
I think tickSpacing 128 (1% fee) is for more volatile tokens.

### Comments

Happy to rename, but shouldn't we stay consistent with naming defined here: https://github.com/orca-so/whirlpools/blob/main/sdk/tests/utils/index.ts ?

### Bugfixes
PR#66: https://github.com/orca-so/whirlpools/pull/66

https://github.com/garbles-labs/Solana.Unity-Core/blob/master/src/Solana.Unity.Dex/Orca/Swap/SwapUtils.cs#L74

### Solution

- Implemented the fix in the PR and added test cases

### DecimalUtil
👉In my experience, Solana newbies get confused with Decimals. I think it would be good to have a utility for u64/Decimal conversion.

https://github.com/orca-so/orca-sdks/blob/main/packages/common-sdk/src/math/decimal-util.ts

### Solution

- Implemented and added test cases

### ATA for Wrapped SOL
I think it would be better to specify somewhere that the ATA for Wrapped SOL can be closed.

### Solution

- Added a parameter unwrapSol to specify if the user want to close the the ATA for Wrapped SOL. True by default

# Orca/Orca/OrcaDex.cs
## L67
https://github.com/garbles-labs/Solana.Unity-Core/blob/master/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs#L67

amountSpecifiedTokenType, tokenAuthority are not used

### Solution

- Removed

## L114
https://github.com/garbles-labs/Solana.Unity-Core/blob/master/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs#L114

&& swapQuote.BtoA ?

### Solution

- Fixed with && !swapQuote.AtoB

## L334
https://github.com/garbles-labs/Solana.Unity-Core/blob/master/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs#L334

Cannot close if fees or rewards remain

https://github.com/orca-so/whirlpools/blob/main/sdk/src/impl/whirlpool-impl.ts#L448

### Solution

- Added collect fees and reward, if available, before closign

## L353
https://github.com/garbles-labs/Solana.Unity-Core/blob/master/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs#L353

If only max is specified, there is no room for slippage to be set.

If there is even a slight price movement, it will fail.

### Solution

- Solved with above solution

## L647
https://github.com/garbles-labs/Solana.Unity-Core/blob/master/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs#L647

Can't find a pool with ts = 1?

### Solution

- Added 1 to the search space

## General
I wonder if ATAs need to be created for increaseLiquidity, decreaseLiquidity, collectFees and collectReward as well.

### Comments

- All tests are passing, but I will investigate more